### PR TITLE
--verbosity argument

### DIFF
--- a/webdriver_test_tools/config/test.py
+++ b/webdriver_test_tools/config/test.py
@@ -12,13 +12,19 @@ class TestSuiteConfig(object):
 
     # Configure test runner
     RUNNER_CLASS = ColourTextTestRunner
-    RUNNER_KWARGS = {'verbosity': 2}
+    RUNNER_KWARGS = {}
+    # TODO: document
+    DEFAULT_VERBOSITY = 2
 
     # Functions
 
     # TODO: update to handle --verbosity arg
     @classmethod
-    def get_runner(cls):
-        """Returns :attr:`RUNNER_CLASS` object using :attr:`RUNNER_KWARGS` to initialize"""
-        return cls.RUNNER_CLASS(**cls.RUNNER_KWARGS)
+    def get_runner(cls, verbosity=None):
+        """Returns :attr:`RUNNER_CLASS` object using :attr:`RUNNER_KWARGS` to
+        initialize
+        """
+        if verbosity is None:
+            verbosity = cls.DEFAULT_VERBOSITY
+        return cls.RUNNER_CLASS(verbosity=verbosity, **cls.RUNNER_KWARGS)
 

--- a/webdriver_test_tools/config/test.py
+++ b/webdriver_test_tools/config/test.py
@@ -16,6 +16,7 @@ class TestSuiteConfig(object):
 
     # Functions
 
+    # TODO: update to handle --verbosity arg
     @classmethod
     def get_runner(cls):
         """Returns :attr:`RUNNER_CLASS` object using :attr:`RUNNER_KWARGS` to initialize"""

--- a/webdriver_test_tools/config/test.py
+++ b/webdriver_test_tools/config/test.py
@@ -1,28 +1,42 @@
 from colour_runner.runner import ColourTextTestRunner
 
 
-class TestSuiteConfig(object):
+class TestSuiteConfig:
     """Configurations for test suite
 
     :var TestSuiteConfig.RUNNER_CLASS: ``unittest.TestRunner`` class to use when running
         tests
     :var TestSuiteConfig.RUNNER_KWARGS: Dictionary mapping parameter names to desired
         values used to initialize the ``TestRunner`` configured in :attr:`RUNNER_CLASS`
+    :var TestSuiteConfig.DEFAULT_VERBOSITY: Value used if the ``verbosity`` parameter is
+        unspecified when calling :meth:`get_runner()`.
+
+        .. note::
+
+            - Conflict may occur if ``'verbosity'`` is set in :attr:`RUNNER_KWARGS`.
+              Be sure to use :attr:`DEFAULT_VERBOSITY` instead for setting this value.
+            - :meth:`get_runner()` assumes the :attr:`RUNNER_CLASS` constructor takes a
+              ``verbosity`` parameter in its constructor. If using a custom test runner
+              class that doesn't support this, you should override the
+              :meth:`get_runner()` method in your project's ``TestSuiteConfig`` class.
     """
 
     # Configure test runner
     RUNNER_CLASS = ColourTextTestRunner
     RUNNER_KWARGS = {}
-    # TODO: document
     DEFAULT_VERBOSITY = 2
 
     # Functions
 
-    # TODO: update to handle --verbosity arg
     @classmethod
     def get_runner(cls, verbosity=None):
         """Returns :attr:`RUNNER_CLASS` object using :attr:`RUNNER_KWARGS` to
         initialize
+
+        :param verbosity: (Optional) value to use for the ``verbosity`` parameter when
+            initializing the test runner. Uses :attr:`DEFAULT_VERBOSITY` if unspecified.
+
+        :return: The initialized ``TestRunner`` object
         """
         if verbosity is None:
             verbosity = cls.DEFAULT_VERBOSITY

--- a/webdriver_test_tools/project/templates/config/test.py.j2
+++ b/webdriver_test_tools/project/templates/config/test.py.j2
@@ -4,13 +4,16 @@ from webdriver_test_tools.config import test
 class TestSuiteConfig(test.TestSuiteConfig):
     """Configurations for test suite
 
-    :var TestSuiteConfig.RUNNER_CLASS: unittest TestRunner class to use when running
+    :var TestSuiteConfig.RUNNER_CLASS: ``unittest.TestRunner`` class to use when running
         tests
     :var TestSuiteConfig.RUNNER_KWARGS: Dictionary mapping parameter names to desired
-        values used to initialize the TestRunner
+        values used to initialize the ``TestRunner`` configured in :attr:`RUNNER_CLASS`
+    :var TestSuiteConfig.DEFAULT_VERBOSITY: Value used if the ``verbosity`` parameter is
+        unspecified when calling :meth:`get_runner()`.
     """
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
     # RUNNER_CLASS = ColourTextTestRunner
-    # RUNNER_KWARGS = {'verbosity': 2}
+    # RUNNER_KWARGS = {}
+    # DEFAULT_VERBOSITY = 2
     pass
 

--- a/webdriver_test_tools/project/test_module.py
+++ b/webdriver_test_tools/project/test_module.py
@@ -22,12 +22,13 @@ def main(tests_module, config_module=None, package_name=None):
     if config_module is None:
         config_module = config
     # Older projects may not have the BrowserConfig or BrowserStackConfig class
-    # TODO: remove BrowserConfig check
-    browser_config = config_module.BrowserConfig if 'BrowserConfig' in dir(config_module) else config.BrowserConfig
+    browser_config = config_module.BrowserConfig # TODO: remove: if 'BrowserConfig' in dir(config_module) else config.BrowserConfig
     browserstack_config = config_module.BrowserStackConfig if 'BrowserStackConfig' in dir(config_module) else config.BrowserStackConfig
     # Parse arguments
     parser = get_parser(browser_config, browserstack_config, package_name)
     args = parser.parse_args()
+    # TODO: make kwargs dict instead to ensure optional arguments are not dependent on position?
+    # kwargs = {}
     # get --test, --skip, and --module args
     test_class_map = parse_test_names(args.test)
     skip_class_map = parse_test_names(args.skip)
@@ -44,7 +45,6 @@ def main(tests_module, config_module=None, package_name=None):
     browser_config_class = browserstack_config if browserstack else browser_config
     # Handle --browser args
     browser_classes = browser_config_class.get_browser_classes(args.browser)
-    # TODO: make kwargs dict instead to ensure optional arguments are not dependent on position?
     # Output options
     verbosity = args.verbosity
     # Run tests using parsed args
@@ -115,7 +115,6 @@ def get_parser(browser_config=None, browserstack_config=None, package_name=None)
                              1 - Final results and progress indicator
                              2 - Full output
                              ''')
-    # TODO: default?
     group.add_argument('-v', '--verbosity', type=int, choices=[0, 1, 2],
                        metavar='<level>', help=verbosity_help)
     # Command arguments
@@ -238,7 +237,6 @@ def list_tests(tests_module, test_module_names=None, test_class_map=None, skip_c
             print(textwrap.indent(test_case, cmd.INDENT))
 
 
-# TODO: update docs
 def run_tests(tests_module, config_module, browser_classes=None,
               test_class_map=None, skip_class_map=None, test_module_names=None,
               browserstack=False, headless=False, verbosity=None):
@@ -249,16 +247,18 @@ def run_tests(tests_module, config_module, browser_classes=None,
         :mod:`webdriver_test_tools.config` if not specified
     :param browser_classes: (Optional) List of browser test classes from parsed arg
         for ``--browser`` command line argument
-    :param test_class_map: (Optional) Result of passing parsed arg for ``--test`` command
-        line argument to :func:`parse_test_names()`
-    :param skip_class_map: (Optional) Result of passing parsed arg for ``--skip`` command
-        line argument to :func:`parse_test_names()`
-    :param test_module_names: (Optional) Parsed arg for ``--module`` command line argument
+    :param test_class_map: (Optional) Result of passing parsed arg for ``--test``
+        command line argument to :func:`parse_test_names()`
+    :param skip_class_map: (Optional) Result of passing parsed arg for ``--skip``
+        command line argument to :func:`parse_test_names()`
+    :param test_module_names: (Optional) Parsed arg for ``--module`` command line
+        argument
     :param browserstack: (Default = False) If True, generated test cases should run on
         BrowserStack
     :param headless: (Default = False) If True, configure driver to run tests in a
         headless browser. Tests will only be generated for drivers that support
         running headless browsers
+    :param verbosity: (Optional) Output verbosity level for the test runner.
     """
     # Enable graceful Ctrl+C handling
     unittest.installHandler()

--- a/webdriver_test_tools/project/test_module.py
+++ b/webdriver_test_tools/project/test_module.py
@@ -103,7 +103,17 @@ def get_parser(browser_config=None, browserstack_config=None, package_name=None)
     if browserstack_config.ENABLE:
         browserstack_help = 'Run tests on BrowserStack instead of locally'
         group.add_argument('-B', '--browserstack', action='store_true', help=browserstack_help)
-    # Misc arguments
+    # Output arguments
+    group = parser.add_argument_group('Output Options')
+    verbosity_help = textwrap.dedent('''\
+                             0 - Final results only
+                             1 - Final results and progress indicator
+                             2 - Full output
+                             ''')
+    # TODO: default?
+    group.add_argument('-v', '--verbosity', type=int, choices=[0, 1, 2], metavar='<level>',
+                       help=verbosity_help)
+    # Command arguments
     group = parser.add_argument_group('Commands')
     help_help = 'Show this help message and exit'
     group.add_argument('-h', '--help', action='help', help=help_help)


### PR DESCRIPTION
## Pull Request Description

### Overview

Added `--verbosity` command line argument. Configures the output level of the test runner

### Details

* Added `--verbosity` argument, which is used to configure the TestRunner output
* Added `TestSuiteConfig.DEFAULT_VERBOSITY` which is used in `get_runner()` if verbosity parameter is set to `None`
* Updated template `test` config 
* Misc. code cleanup


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update

