### PR TITLE
Feature/assertion wait timeout

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -177,6 +177,7 @@ autodoc_member_order = 'bysource'
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
+# TODO: add selenium
 intersphinx_mapping = {
         'https://docs.python.org/': None,
         'randomuser': ('https://connordelacruz.com/python-randomuser', None),

--- a/webdriver_test_tools/__about__.py
+++ b/webdriver_test_tools/__about__.py
@@ -18,6 +18,7 @@ __url__ = 'https://github.com/connordelacruz/webdriver-test-tools/'
 __documentation__ = 'https://connordelacruz.com/webdriver-test-tools/'
 __download__ = __url__ + 'archive/{}.tar.gz'.format(__version__)
 
+# TODO: look into upgrading
 __selenium__ = '3.11.0'
 
 __author__ = 'Connor de la Cruz'

--- a/webdriver_test_tools/pageobject/modal.py
+++ b/webdriver_test_tools/pageobject/modal.py
@@ -1,6 +1,7 @@
+from selenium.common.exceptions import NoSuchElementException
+
 from webdriver_test_tools.pageobject import BasePage
 from webdriver_test_tools.webdriver import actions
-from webdriver_test_tools.webdriver.support import test
 
 
 class ModalObject(BasePage):
@@ -29,8 +30,10 @@ class ModalObject(BasePage):
 
         :return: True if the modal is displayed, False otherwise
         """
-        driver = self.driver
-        displayed = test.element_exists(driver, self.MODAL_LOCATOR) and self.find_element(self.MODAL_LOCATOR).is_displayed()
+        try:
+            displayed = self.find_element(self.MODAL_LOCATOR).is_displayed()
+        except NoSuchElementException:
+            displayed = False
         return displayed
 
     def click_close_button(self):

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -1,8 +1,8 @@
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import ActionChains
 
 from webdriver_test_tools.pageobject import BasePage
 from webdriver_test_tools.webdriver import actions
-from webdriver_test_tools.webdriver.support import test
 
 
 class NavObject(BasePage):
@@ -88,9 +88,10 @@ class CollapsibleNavObject(NavObject):
 
         :return: True if the nav menu is expanded, False if it's collapsed
         """
-        driver = self.driver
-        expanded = test.element_exists(driver, self.MENU_CONTAINER_LOCATOR) and self.find_element(
-            self.MENU_CONTAINER_LOCATOR).is_displayed()
+        try:
+            expanded = self.find_element(self.MENU_CONTAINER_LOCATOR).is_displayed()
+        except NoSuchElementException:
+            expanded = False
         return expanded
 
     def click_expand_button(self):

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -43,6 +43,12 @@ has additional assertions:
 | <WebDriverTestCase.assertBaseUrlChange>` | matches ``expected_url``            |
 +------------------------------------------+-------------------------------------+
 
+Each of these assertion methods accepts the following optional keyword arguments:
+
+- ``msg``: If specified, used as the error message on failure
+- ``wait_timeout``: (Default = 10) Number of seconds to wait for expected
+  conditions to occur before test fails
+
 .. _assertion methods: https://docs.python.org/library/unittest.html#assert-methods
 
 """
@@ -186,7 +192,7 @@ class WebDriverTestCase(unittest.TestCase):
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
         """
-        if not test.element_exists_test(self.driver, element_locator, test_exists=True, wait_timeout=wait_timeout):
+        if not test.existence_change_test(self.driver, element_locator, test_exists=True, wait_timeout=wait_timeout):
             failure_message = 'No elements located using ' + self._locator_string(element_locator)
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
@@ -201,7 +207,7 @@ class WebDriverTestCase(unittest.TestCase):
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
         """
-        if not test.element_exists_test(self.driver, element_locator, test_exists=False, wait_timeout=wait_timeout):
+        if not test.existence_change_test(self.driver, element_locator, test_exists=False, wait_timeout=wait_timeout):
             failure_message = 'Elements located using ' + self._locator_string(element_locator)
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
@@ -276,7 +282,7 @@ class WebDriverTestCase(unittest.TestCase):
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
         """
-        if not test.element_enabled_test(self.driver, element_locator, test_enabled=True, wait_timeout=wait_timeout):
+        if not test.enabled_state_change_test(self.driver, element_locator, test_enabled=True, wait_timeout=wait_timeout):
             failure_message = 'Element is disabled'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
@@ -291,7 +297,7 @@ class WebDriverTestCase(unittest.TestCase):
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
         """
-        if not test.element_enabled_test(self.driver, element_locator, test_enabled=False, wait_timeout=wait_timeout):
+        if not test.enabled_state_change_test(self.driver, element_locator, test_enabled=False, wait_timeout=wait_timeout):
             failure_message = 'Element is enabled'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -176,16 +176,12 @@ class WebDriverTestCase(unittest.TestCase):
         """
         return '("{0}", "{1}")'.format(*locator)
 
-    # TODO: make sure assertions use methods that wrap expected condition classes
-    # TODO: add optional wait_timeout param to assertions
-    # TODO: update docstrings to include wait_timeout
-
     def assertExists(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element doesn't exist
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -200,7 +196,7 @@ class WebDriverTestCase(unittest.TestCase):
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -215,7 +211,7 @@ class WebDriverTestCase(unittest.TestCase):
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -230,7 +226,7 @@ class WebDriverTestCase(unittest.TestCase):
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -245,7 +241,7 @@ class WebDriverTestCase(unittest.TestCase):
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -260,7 +256,7 @@ class WebDriverTestCase(unittest.TestCase):
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -270,26 +266,32 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    # TODO: wait_timeout
     def assertEnabled(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element is disabled
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (Optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not self.driver.find_element(*element_locator).is_enabled():
+        if not test.element_enabled_test(self.driver, element_locator, test_enabled=True, wait_timeout=wait_timeout):
             failure_message = 'Element is disabled'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    # TODO: wait_timeout
     def assertDisabled(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element is enabled
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (Optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if self.driver.find_element(*element_locator).is_enabled():
+        if not test.element_enabled_test(self.driver, element_locator, test_enabled=False, wait_timeout=wait_timeout):
             failure_message = 'Element is enabled'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
@@ -302,7 +304,7 @@ class WebDriverTestCase(unittest.TestCase):
         not match the current URL.
 
         :param expected_url: The expected URL
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
@@ -323,7 +325,7 @@ class WebDriverTestCase(unittest.TestCase):
         not match the current URL.
 
         :param expected_url: The expected URL
-        :param msg: (optional) if specified, used as the error message on
+        :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -176,31 +176,36 @@ class WebDriverTestCase(unittest.TestCase):
         """
         return '("{0}", "{1}")'.format(*locator)
 
-
     # TODO: make sure assertions use methods that wrap expected condition classes
     # TODO: add optional wait_timeout param to assertions
     # TODO: update docstrings to include wait_timeout
 
-    # TODO: wait_timeout
-    def assertExists(self, element_locator, msg=None):
+    def assertExists(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element doesn't exist
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not test.element_exists(self.driver, element_locator):
+        if not test.element_exists_test(self.driver, element_locator, test_exists=True, wait_timeout=wait_timeout):
             failure_message = 'No elements located using ' + self._locator_string(element_locator)
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    # TODO: wait_timeout
-    def assertNotExists(self, element_locator, msg=None):
+    def assertNotExists(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element exists
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if test.element_exists(self.driver, element_locator):
+        if not test.element_exists_test(self.driver, element_locator, test_exists=False, wait_timeout=wait_timeout):
             failure_message = 'Elements located using ' + self._locator_string(element_locator)
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
@@ -266,7 +271,7 @@ class WebDriverTestCase(unittest.TestCase):
             raise self.failureException(msg)
 
     # TODO: wait_timeout
-    def assertEnabled(self, element_locator, msg=None):
+    def assertEnabled(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element is disabled
 
         :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
@@ -278,7 +283,7 @@ class WebDriverTestCase(unittest.TestCase):
             raise self.failureException(msg)
 
     # TODO: wait_timeout
-    def assertDisabled(self, element_locator, msg=None):
+    def assertDisabled(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element is enabled
 
         :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -176,6 +176,12 @@ class WebDriverTestCase(unittest.TestCase):
         """
         return '("{0}", "{1}")'.format(*locator)
 
+
+    # TODO: make sure assertions use methods that wrap expected condition classes
+    # TODO: add optional wait_timeout param to assertions
+    # TODO: update docstrings to include wait_timeout
+
+    # TODO: wait_timeout
     def assertExists(self, element_locator, msg=None):
         """Fail if element doesn't exist
 
@@ -187,6 +193,7 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
+    # TODO: wait_timeout
     def assertNotExists(self, element_locator, msg=None):
         """Fail if element exists
 
@@ -198,50 +205,67 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertInView(self, element_locator, msg=None):
+    def assertInView(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element isn't scrolled into view
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not test.in_view_change_test(self.driver, element_locator):
+        if not test.in_view_change_test(self.driver, element_locator, wait_timeout=wait_timeout):
             failure_message = 'Element is not scrolled into view'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertNotInView(self, element_locator, msg=None):
+    def assertNotInView(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element is scrolled into view
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if test.in_view_change_test(self.driver, element_locator):
+        if test.in_view_change_test(self.driver, element_locator, wait_timeout=wait_timeout):
             failure_message = 'Element is scrolled into view'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertVisible(self, element_locator, msg=None):
+    def assertVisible(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element isn't visible
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not test.visibility_change_test(self.driver, element_locator):
+        if not test.visibility_change_test(self.driver, element_locator, wait_timeout=wait_timeout):
             failure_message = 'Element is not visible'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertInvisible(self, element_locator, msg=None):
+    def assertInvisible(self, element_locator, msg=None, wait_timeout=10):
         """Fail if element is visible
 
-        :param element_locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param element_locator: webdriver locator tuple in the format
+            ``(by.<attr>, <locator string>)``
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not test.visibility_change_test(self.driver, element_locator, test_visible=False):
+        if not test.visibility_change_test(self.driver, element_locator, test_visible=False, wait_timeout=wait_timeout):
             failure_message = 'Element is visible'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
+    # TODO: wait_timeout
     def assertEnabled(self, element_locator, msg=None):
         """Fail if element is disabled
 
@@ -253,6 +277,7 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
+    # TODO: wait_timeout
     def assertDisabled(self, element_locator, msg=None):
         """Fail if element is enabled
 
@@ -264,34 +289,44 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertUrlChange(self, expected_url, msg=None):
+    def assertUrlChange(self, expected_url, msg=None, wait_timeout=10):
         """Fail if the URL doesn't match the expected URL.
 
-        Assertion uses webdriver_test_tools.test.url_change_test() using the default 10
-        second wait timeout before determining that expected_url does not match the
-        current URL.
+        Assertion uses webdriver_test_tools.test.url_change_test() using the
+        specified ``wait_timeout`` before determining that expected_url does
+        not match the current URL.
 
         :param expected_url: The expected URL
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not test.url_change_test(self.driver, expected_url):
-            failure_message = 'Current URL = {}, expected URL = {}'.format(self.driver.current_url, expected_url)
+        if not test.url_change_test(self.driver, expected_url, wait_timeout=wait_timeout):
+            failure_message = 'Current URL = {}, expected URL = {}'.format(
+                self.driver.current_url, expected_url
+            )
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertBaseUrlChange(self, expected_url, msg=None):
-        """Fail if the URL (ignoring query strings) doesn't match the expected URL.
+    def assertBaseUrlChange(self, expected_url, msg=None, wait_timeout=10):
+        """Fail if the URL (ignoring query strings) doesn't match the expected
+        URL.
 
-        Assertion uses webdriver_test_tools.test.url_change_test() using the default 10
-        second wait timeout before determining that expected_url does not match the
-        current URL.
+        Assertion uses webdriver_test_tools.test.url_change_test() using the
+        specified ``wait_timeout`` before determining that expected_url does
+        not match the current URL.
 
         :param expected_url: The expected URL
-        :param msg: (Optional) If specified, used as the error message on failure
+        :param msg: (optional) if specified, used as the error message on
+            failure
+        :param wait_timeout: (Default = 10) Number of seconds to wait for
+            expected conditions to occur before test fails
         """
-        if not test.base_url_change_test(self.driver, expected_url):
+        if not test.base_url_change_test(self.driver, expected_url, wait_timeout=wait_timeout):
             failure_message = 'Current base URL = {}, expected base URL = {}'.format(
-                utils.get_base_url(self.driver.current_url), expected_url)
+                utils.get_base_url(self.driver.current_url), expected_url
+            )
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 

--- a/webdriver_test_tools/webdriver/support/expected_conditions.py
+++ b/webdriver_test_tools/webdriver/support/expected_conditions.py
@@ -1,13 +1,13 @@
 """Custom expected condition classes"""
 from selenium.common.exceptions import NoSuchElementException
 
-from . import test
 from webdriver_test_tools.common import utils
 
 
-# TODO: add expected conditions for all basic tests that don't have one
 # TODO: add inverse conditions for each? at least for consistency
 # TODO: make class names consistent with selenium's absurd naming conventions
+
+# Expected Condition Classes
 
 class element_to_exist:
     """Custom wait condition for WebdriverWait() that checks if an element
@@ -17,7 +17,7 @@ class element_to_exist:
         self.locator = locator
 
     def __call__(self, driver):
-        return test.element_exists(driver, self.locator)
+        return _element_exists(driver, self.locator)
 
 
 class element_to_not_exist:
@@ -28,7 +28,7 @@ class element_to_not_exist:
         self.locator = locator
 
     def __call__(self, driver):
-        return not test.element_exists(driver, self.locator)
+        return not _element_exists(driver, self.locator)
 
 
 class element_to_be_enabled:
@@ -64,7 +64,7 @@ class element_is_in_view:
 
     def __call__(self, driver):
         element = driver.find_element(*self.locator)
-        return test.is_scrolled_into_view(driver, element, self.fully_in_view)
+        return _is_scrolled_into_view(driver, element, self.fully_in_view)
 
 
 class base_url_to_be:
@@ -83,3 +83,55 @@ class base_url_to_be:
         base_url = utils.get_base_url(driver.current_url)
         return self.url == base_url
 
+
+# Helper Methods
+
+def _is_scrolled_into_view(driver, element, fully_in_view=True):
+    """Returns True if the element is scrolled into view, False otherwise
+
+    Currently, Selenium doesn't offer a means of getting an element's location relative
+    to the viewport, so using JavaScript to determine whether the element is visible
+    within the viewport.
+
+    :param driver: Selenium WebDriver object
+    :param element: WebElement for the element to check
+    :param fully_in_view: (Default = True) If True, check that the element is fully in
+        view and not cut off. If False, check that it's at least partially in view
+
+    :return: True if the element is scrolled into view, False otherwise
+    """
+    # the JavaScript used to check if the element is in view.
+    script_string = '''
+    return function(el, strict) {
+        var rect = el.getBoundingClientRect();
+        var elemTop = rect.top;
+        var elemBottom = rect.bottom;
+
+        if (strict)
+            var isVisible = (elemTop >= 0) && (elemBottom <= window.innerHeight);
+        else
+            isVisible = elemTop < window.innerHeight && elemBottom >= 0;
+        return isVisible;
+    }(arguments[0],arguments[1])
+    '''
+    return driver.execute_script(script_string, element, fully_in_view)
+
+
+def _element_exists(driver, element_locator):
+    """Returns True if the element exists, False if not
+
+    This function is just a wrapper that catches the NoSuchElementException thrown by
+    driver.find_element() and returns a boolean based on whether the exception occurred.
+    Used for test assertions.
+
+    :param driver: Selenium WebDriver object
+    :param element_locator: Tuple in the format (by,selector) used to locate target
+
+    :return: True if the element exists, False if not
+    """
+    exists = True
+    try:
+        driver.find_element(*element_locator)
+    except NoSuchElementException:
+        exists = False
+    return exists

--- a/webdriver_test_tools/webdriver/support/expected_conditions.py
+++ b/webdriver_test_tools/webdriver/support/expected_conditions.py
@@ -1,15 +1,62 @@
 """Custom expected condition classes"""
+from selenium.common.exceptions import NoSuchElementException
 
 from . import test
 from webdriver_test_tools.common import utils
 
 
 # TODO: add expected conditions for all basic tests that don't have one
+# TODO: add inverse conditions for each? at least for consistency
+# TODO: make class names consistent with selenium's absurd naming conventions
+
+class element_to_exist:
+    """Custom wait condition for WebdriverWait() that checks if an element
+    exists
+    """
+    def __init__(self, locator):
+        self.locator = locator
+
+    def __call__(self, driver):
+        return test.element_exists(driver, self.locator)
 
 
-class element_is_in_view(object):
-    """Custom wait condition for WebDriverWait() that uses JavaScript to check if an
-    element is scrolled into view
+class element_to_not_exist:
+    """Custom wait condition for WebdriverWait() that checks if an element
+    does not exists
+    """
+    def __init__(self, locator):
+        self.locator = locator
+
+    def __call__(self, driver):
+        return not test.element_exists(driver, self.locator)
+
+
+class element_to_be_enabled:
+    """Custom wait condition for WebdriverWait() that checks if an element
+    is enabled
+    """
+    def __init__(self, locator):
+        self.locator = locator
+
+    def __call__(self, driver):
+        return driver.find_element(*self.locator).is_enabled()
+
+
+class element_to_be_disabled:
+    """Custom wait condition for WebdriverWait() that checks if an element
+    is disabled
+    """
+    def __init__(self, locator):
+        self.locator = locator
+
+    def __call__(self, driver):
+        return not driver.find_element(*self.locator).is_enabled()
+
+
+# TODO: element_to_be_in_view? naming conventions for EC are weird
+class element_is_in_view:
+    """Custom wait condition for WebDriverWait() that uses JavaScript to check
+    if an element is scrolled into view
     """
     def __init__(self, locator, fully_in_view=False):
         self.locator = locator
@@ -20,11 +67,12 @@ class element_is_in_view(object):
         return test.is_scrolled_into_view(driver, element, self.fully_in_view)
 
 
-class base_url_to_be(object):
-    """An expectation for checking the current url, ignoring query strings (i.e. strips
-    '?' and everything after it and only looks at the base URL)
+class base_url_to_be:
+    """An expectation for checking the current url, ignoring query strings
+    (i.e. strips '?' and everything after it and only looks at the base URL)
 
-    url is the expected URL, which must be an exact match with the current base URL
+    url is the expected URL, which must be an exact match with the current base
+    URL
 
     returns True if the base URL matches, false otherwise
     """
@@ -34,3 +82,4 @@ class base_url_to_be(object):
     def __call__(self, driver):
         base_url = utils.get_base_url(driver.current_url)
         return self.url == base_url
+

--- a/webdriver_test_tools/webdriver/support/expected_conditions.py
+++ b/webdriver_test_tools/webdriver/support/expected_conditions.py
@@ -4,6 +4,9 @@ from . import test
 from webdriver_test_tools.common import utils
 
 
+# TODO: add expected conditions for all basic tests that don't have one
+
+
 class element_is_in_view(object):
     """Custom wait condition for WebDriverWait() that uses JavaScript to check if an
     element is scrolled into view

--- a/webdriver_test_tools/webdriver/support/expected_conditions.py
+++ b/webdriver_test_tools/webdriver/support/expected_conditions.py
@@ -5,7 +5,6 @@ from webdriver_test_tools.common import utils
 
 
 # TODO: add inverse conditions for each? at least for consistency
-# TODO: make class names consistent with selenium's absurd naming conventions
 
 # Expected Condition Classes
 
@@ -53,8 +52,7 @@ class element_to_be_disabled:
         return not driver.find_element(*self.locator).is_enabled()
 
 
-# TODO: element_to_be_in_view? naming conventions for EC are weird
-class element_is_in_view:
+class element_to_be_in_view:
     """Custom wait condition for WebDriverWait() that uses JavaScript to check
     if an element is scrolled into view
     """

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -1,6 +1,6 @@
 """Functions for commonly repeated test procedures"""
 
-from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -9,62 +9,7 @@ from webdriver_test_tools.webdriver.support import expected_conditions as custom
 # TODO: consistent naming conventions
 # TODO: split up low level tests, expected condition tests into different modules and refactor
 
-
-# Element Tests
-
-def element_exists(driver, element_locator):
-    """Returns True if the element exists, False if not
-
-    This function is just a wrapper that catches the NoSuchElementException thrown by
-    driver.find_element() and returns a boolean based on whether the exception occurred.
-    Used for test assertions.
-
-    :param driver: Selenium WebDriver object
-    :param element_locator: Tuple in the format (by,selector) used to locate target
-
-    :return: True if the element exists, False if not
-    """
-    exists = True
-    try:
-        driver.find_element(*element_locator)
-    except NoSuchElementException:
-        exists = False
-    return exists
-
-
-def is_scrolled_into_view(driver, element, fully_in_view=True):
-    """Returns True if the element is scrolled into view, False otherwise
-
-    Currently, Selenium doesn't offer a means of getting an element's location relative
-    to the viewport, so using JavaScript to determine whether the element is visible
-    within the viewport.
-
-    :param driver: Selenium WebDriver object
-    :param element: WebElement for the element to check
-    :param fully_in_view: (Default = True) If True, check that the element is fully in
-        view and not cut off. If False, check that it's at least partially in view
-
-    :return: True if the element is scrolled into view, False otherwise
-    """
-    # the JavaScript used to check if the element is in view.
-    script_string = '''
-    return function(el, strict) {
-        var rect = el.getBoundingClientRect();
-        var elemTop = rect.top;
-        var elemBottom = rect.bottom;
-
-        if (strict)
-            var isVisible = (elemTop >= 0) && (elemBottom <= window.innerHeight);
-        else
-            isVisible = elemTop < window.innerHeight && elemBottom >= 0;
-        return isVisible;
-    }(arguments[0],arguments[1])
-    '''
-    return driver.execute_script(script_string, element, fully_in_view)
-
-
 # Expected Condition Tests
-# TODO: extract these to another module?
 
 def expected_condition_test(driver, ec_object, wait_timeout=10):
     """Test for an expected condition until wait timeout is reached

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -147,6 +147,8 @@ def base_url_change_test(driver, expected_url, wait_timeout=10):
     return expected_condition_test(driver, url_checker, wait_timeout)
 
 
+# TODO: make these names consistent with other tests
+
 def element_exists_test(driver, target_locator, test_exists=True, wait_timeout=10):
     """Expected condition test for element existence changes (e.g. element that
     gets added/removed dynamically)
@@ -164,4 +166,10 @@ def element_exists_test(driver, target_locator, test_exists=True, wait_timeout=1
     """
     exists_checker = customEC.element_to_exist(target_locator) if test_exists else customEC.element_to_not_exist(target_locator)
     return expected_condition_test(driver, exists_checker, wait_timeout)
+
+
+def element_enabled_test(driver, target_locator, test_enabled=True, wait_timeout=10):
+    # TODO: doc
+    enabled_checker = customEC.element_to_be_enabled(target_locator) if test_enabled else customEC.element_to_be_disabled(target_locator)
+    return expected_condition_test(driver, enabled_checker, wait_timeout)
 

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -38,7 +38,7 @@ def in_view_change_test(driver, target_locator, wait_timeout=10):
 
     :return: True if target is scrolled into view before timeout, False otherwise
     """
-    in_view_checker = customEC.element_is_in_view(target_locator)
+    in_view_checker = customEC.element_to_be_in_view(target_locator)
     return expected_condition_test(driver, in_view_checker, wait_timeout)
 
 

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -146,3 +146,22 @@ def base_url_change_test(driver, expected_url, wait_timeout=10):
     url_checker = customEC.base_url_to_be(expected_url)
     return expected_condition_test(driver, url_checker, wait_timeout)
 
+
+def element_exists_test(driver, target_locator, test_exists=True, wait_timeout=10):
+    """Expected condition test for element existence changes (e.g. element that
+    gets added/removed dynamically)
+
+    :param driver: Selenium WebDriver object
+    :param target_locator: Tuple in the format (by,selector) used to locate target
+    :param test_exists: (Default = True) An optional variable describing what
+        the existence change is supposed to be. If True, test if the target does
+        exist. If False, test if the target no longer exists
+    :param wait_timeout: (Default = 10) Number of seconds to wait for expected
+        conditions to occur before timing out
+
+    :return: True if the existence of the target changes as expected, False
+        otherwise
+    """
+    exists_checker = customEC.element_to_exist(target_locator) if test_exists else customEC.element_to_not_exist(target_locator)
+    return expected_condition_test(driver, exists_checker, wait_timeout)
+

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -7,6 +7,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from webdriver_test_tools.webdriver.support import expected_conditions as customEC
 
 # TODO: consistent naming conventions
+# TODO: split up low level tests, expected condition tests into different modules and refactor
 
 
 # Element Tests

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -6,8 +6,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from webdriver_test_tools.webdriver.support import expected_conditions as customEC
 
-# TODO: consistent naming conventions
-# TODO: split up low level tests, expected condition tests into different modules and refactor
 
 # Expected Condition Tests
 
@@ -92,9 +90,7 @@ def base_url_change_test(driver, expected_url, wait_timeout=10):
     return expected_condition_test(driver, url_checker, wait_timeout)
 
 
-# TODO: make these names consistent with other tests
-
-def element_exists_test(driver, target_locator, test_exists=True, wait_timeout=10):
+def existence_change_test(driver, target_locator, test_exists=True, wait_timeout=10):
     """Expected condition test for element existence changes (e.g. element that
     gets added/removed dynamically)
 
@@ -113,8 +109,17 @@ def element_exists_test(driver, target_locator, test_exists=True, wait_timeout=1
     return expected_condition_test(driver, exists_checker, wait_timeout)
 
 
-def element_enabled_test(driver, target_locator, test_enabled=True, wait_timeout=10):
-    # TODO: doc
+def enabled_state_change_test(driver, target_locator, test_enabled=True, wait_timeout=10):
+    """Expected condition test for element enabled/disabled state changes
+
+    :param driver: Selenium WebDriver object
+    :param target_locator: Tuple in the format (by,selector) used to locate target
+    :param test_enabled: (Default = True) An optional variable describing what
+        the enabled/disabled state change is supposed to be. If True, test if
+        the target is enabled. If False, test if the target is disabled
+    :param wait_timeout: (Default = 10) Number of seconds to wait for expected
+        conditions to occur before timing out
+    """
     enabled_checker = customEC.element_to_be_enabled(target_locator) if test_enabled else customEC.element_to_be_disabled(target_locator)
     return expected_condition_test(driver, enabled_checker, wait_timeout)
 


### PR DESCRIPTION
## Pull Request Description

### Overview

Added optional parameter `wait_timeout` to the custom assertion methods in `WebDriverTestCase`. Also reorganized code in `webdriver.support` subpackage in a way that makes more sense and removes circular imports.


### Details

*Test Cases:*

- Added optional parameter `wait_timeout` to `WebDriverTestCase` assertion methods that wrap expected condition tests, allowing users to override the default time of 10 seconds for conditions that may take longer to occur

*Expected Conditions:*

- Added expected condition classes for elements existing/not existing and enabled/disabled states

*WebDriver Test Module:*

- Moved `element_exists()` and `is_scrolled_into_view()` out of `test` module. They're now "private" methods in the `expected_conditions` module
- Added expected condition test functions `existence_change_test()` and `enabled_state_change_test()` that use the new expected condition classes

*Page Object Prototypes:*

- `ModalObject` and `NavObject` no longer use `test.element_exists()` and instead wrap calls to `self.find_element()` in a `try`/`except` that catches `NoSuchElementException` and uses that instead 


## Types of Changes

Please delete options that don't apply.

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update
