### PR TITLE
Config template updates

### DIFF
--- a/docs/example/example-project/README.rst
+++ b/docs/example/example-project/README.rst
@@ -66,8 +66,31 @@ For info on command line arguments, use the ``--help`` (or ``-h``) argument:
     python -m example_package --help
 
 
+Creating New Project Files
+--------------------------
+
+New tests and page objects can be generated using the ``new`` command:
+
+::
+
+    python -m example_package new [<type>] [<module_name>] [<ClassName>] [-d
+    <description>] [-f]
+
+Where:
+
+- ``<type>``: The type of file to create (``test`` or ``page``)
+- ``<module_name>``: Filename to use for the new python module
+- ``<ClassName>``: Name to use for the initial class
+- ``<description>``: (Optional) Description for the initial class
+- ``-f``: (Optional) Force overwrite if a file with the same name already exists
+
+If no arguments are provided, a prompt will walk you through generating the new
+file. Alternatively, you can skip the prompts by using the arguments shown in
+the following sections.
+
+
 Creating New Tests
-------------------
+~~~~~~~~~~~~~~~~~~
 
 New test modules can be generated using the ``new test`` command:
 
@@ -97,7 +120,7 @@ used to force overwrite existing files:
 
 
 Creating New Page Objects
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New page object modules can be generated using the ``new page`` command:
 
@@ -129,12 +152,18 @@ used to force overwrite existing files:
 Running Tests
 -------------
 
+Basic Usage
+~~~~~~~~~~~
+
 To run all tests:
 
 ::
 
     python -m example_package
 
+
+Running Specific Tests
+~~~~~~~~~~~~~~~~~~~~~~
 
 To run all test cases in one or more modules, use the ``--module`` (or ``-m``)
 argument:
@@ -156,6 +185,9 @@ To skip certain test cases or methods, use the ``--skip`` (or ``-s``) argument:
 
     python -m example_package --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
+
+The ``--test`` and ``--skip`` arguments both support wildcards (``*``) in class
+and method names.
 
 These arguments can be used together. When combined, they are processed in the
 following order:
@@ -285,8 +317,7 @@ inside the project directory:
         │   ├── site.py
         │   ├── test.py
         │   └── webdriver.py
-        ├── data/
-        │   └── __init__.py
+        ├── data.py
         ├── log/
         ├── pages/
         │   └── __init__.py
@@ -313,6 +344,8 @@ Test Package Root Contents
 * ``__main__.py``: Required to run tests from the command line. 
 * ``__init__.py``: Empty init file so Python recognizes the directory as a
   package.
+* ``data.py``: Module for storing static data for tests that must use specific
+  values (e.g. emails, usernames, etc).
 
 
 Test Package Directories
@@ -330,13 +363,6 @@ python unittest framework.
 * ``site.py``: Configure URLs used for testing.
 * ``test.py``: Configure the ``unittest.TestRunner`` class.
 * ``webdriver.py``: Configure WebDrivers and log output directory.
-
-
-data/
-~~~~~
-
-Static data for tests that must use specific values (e.g. emails, usernames,
-etc).
 
 log/
 ~~~~
@@ -369,7 +395,7 @@ generating new test modules.
 
 |webdriver_test_tools|
 
-.. |webdriver_test_tools| image:: https://img.shields.io/badge/generated%20using-webdriver__test__tools%201.7.1-blue.svg?style=for-the-badge
-    :alt: webdriver_test_tools 1.7.1
+.. |webdriver_test_tools| image:: https://img.shields.io/badge/generated%20using-webdriver__test__tools%202.5.0-blue.svg?style=for-the-badge
+    :alt: webdriver_test_tools 2.5.0
 
 

--- a/docs/example/example-project/example_package/config/browser.py
+++ b/docs/example/example-project/example_package/config/browser.py
@@ -3,13 +3,11 @@ from webdriver_test_tools.config import browser
 
 
 class BrowserConfig(browser.BrowserConfig):
-    """Configurations for which browsers to generate tests for
+    """Configurations for which browsers to generate tests for"""
 
-    :var BrowserConfig.ENABLED_BROWSERS: Dictionary mapping browser names to a boolean.
-        True enables the browser, False disables it. Defaults to Chrome and
-        Firefox since they're not platform specific
-    """
-
+    # Dictionary mapping browser names to a boolean. True enables the browser,
+    # False disables it. Defaults to Chrome and Firefox since they're not
+    # platform specific
     ENABLED_BROWSERS = {
         Browsers.FIREFOX: True,
         Browsers.CHROME: True,

--- a/docs/example/example-project/example_package/config/browserstack.py
+++ b/docs/example/example-project/example_package/config/browserstack.py
@@ -1,29 +1,31 @@
+import os
 from webdriver_test_tools.config import browserstack
 from webdriver_test_tools.testcase.browsers import *
 
 
 class BrowserStackConfig(browserstack.BrowserStackConfig):
-    """Configurations for BrowserStack testing
+    """Configurations for BrowserStack testing"""
 
-    :var BrowserStackConfig.ENABLE: (Default = False) Set to True to enable BrowserStack testing
-    :var BrowserStackConfig.USERNAME: Account username. Required for BrowserStack testing
-    :var BrowserStackConfig.ACCESS_KEY: Access key. Required for BrowserStack testing
-    :var BrowserStackConfig.BS_CAPABILITIES: BrowserStack test configurations
-    :var BrowserStackConfig.ENABLED_BROWSERS: Dictionary mapping browser names to a boolean.
-        True enables the browser, False disables it. Defaults to Chrome and
-        Firefox since they're not platform specific
-    """
+    # Required Configurations
 
+    # (Default = False) Set to True to enable BrowserStack testing
     ENABLE = False
-    USERNAME = ''
-    ACCESS_KEY = ''
 
-    BS_CAPABILITIES = {
-        'project': 'example_package',
-        'browserstack.video': False,
-        # 'browserstack.selenium_version': '3.11.0',
-    }
+    # Account username. Required for BrowserStack testing.
+    # Uses the value of BROWSERSTACK_USERNAME environment variable by default
+    USERNAME = os.getenv('BROWSERSTACK_USERNAME', '')
 
+    # Access key. Required for BrowserStack testing.
+    # Uses the value of BROWSERSTACK_ACCESS_KEY environment variable by 
+    # default
+    ACCESS_KEY = os.getenv('BROWSERSTACK_ACCESS_KEY', '')
+
+
+    # Browsers
+
+    # Dictionary mapping browser names to a boolean. True enables the browser,
+    # False disables it. Defaults to Chrome and Firefox since they're not
+    # platform specific
     ENABLED_BROWSERS = {
         Browsers.FIREFOX: True,
         Browsers.CHROME: True,
@@ -34,3 +36,11 @@ class BrowserStackConfig(browserstack.BrowserStackConfig):
     }
 
 
+    # Advanced Configurations
+
+    # BrowserStack test configurations
+    BS_CAPABILITIES = {
+        'project': 'example_package',
+        'browserstack.video': False,
+        # 'browserstack.selenium_version': '3.11.0',
+    }

--- a/docs/example/example-project/example_package/config/site.py
+++ b/docs/example/example-project/example_package/config/site.py
@@ -2,13 +2,13 @@ from webdriver_test_tools.config import site
 
 
 class SiteConfig(site.SiteConfig):
-    """URL configurations for a site
-
-    :var SiteConfig.SITE_URL: URL of the home page
-    :var SiteConfig.BASE_URL: Base URL for site pages (followed by a '/')
-    """
+    """URL configurations for a site"""
+    # URL of the home page
     SITE_URL = 'https://example.com'
+    # Base URL for site pages (followed by a '/')
     BASE_URL = SITE_URL + '/'
+
     # DECLARE ANY OTHER URL VARIABLES NEEDED FOR TESTING HERE
+
     # URL linked to by the 'More Information' link on example.com
     INFO_URL = 'https://www.iana.org/domains/reserved'

--- a/docs/example/example-project/example_package/config/test.py
+++ b/docs/example/example-project/example_package/config/test.py
@@ -2,17 +2,19 @@ from webdriver_test_tools.config import test
 
 
 class TestSuiteConfig(test.TestSuiteConfig):
-    """Configurations for test suite
+    """Configurations for test suite"""
 
-    :var TestSuiteConfig.RUNNER_CLASS: ``unittest.TestRunner`` class to use when running
-        tests
-    :var TestSuiteConfig.RUNNER_KWARGS: Dictionary mapping parameter names to desired
-        values used to initialize the ``TestRunner`` configured in :attr:`RUNNER_CLASS`
-    :var TestSuiteConfig.DEFAULT_VERBOSITY: Value used if the ``verbosity`` parameter is
-        unspecified when calling :meth:`get_runner()`.
-    """
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
+
+    # unittest.TestRunner class to use when running tests
     # RUNNER_CLASS = ColourTextTestRunner
+
+    # Dictionary mapping parameter names to desired values used to initialize
+    # the TestRunner configured in RUNNER_CLASS
     # RUNNER_KWARGS = {}
+
+    # Value used if the verbosity parameter is unspecified when calling
+    # get_runner()
     # DEFAULT_VERBOSITY = 2
+
     pass

--- a/docs/example/example-project/example_package/config/webdriver.py
+++ b/docs/example/example-project/example_package/config/webdriver.py
@@ -5,60 +5,69 @@ import example_package
 
 
 class WebDriverConfig(config.WebDriverConfig):
-    """Configurations for webdriver
+    """Configurations for webdriver"""
 
-    :var WebDriverConfig.LOG_PATH: Path to the log directory. Defaults to the log
-        subdirectory in the webdriver_test_tools package root directory
-    :var WebDriverConfig.SCREENSHOT_PATH: Path to the screenshot directory. Defaults
-        to the screenshot subdirectory in the webdriver_test_tools package root directory
-    :var WebDriverConfig.IMPLICIT_WAIT: Implicit wait time for webdriver to poll DOM
+    # File Path Configurations
 
-        .. note::
-
-            Documentation says not to mix this with explicit waits and some instability
-            was noticed when it was set to 10. Projects can override this if necessary.
-            `Implicit wait documentation
-            <https://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#explicit-and-implicit-waits>`__
-
-    Browser driver initialization arguments:
-
-    :var WebDriverConfig.FIREFOX_KWARGS: Keyword args for webdriver.Firefox()
-    :var WebDriverConfig.CHROME_KWARGS: Keyword args for webdriver.Chrome()
-    :var WebDriverConfig.SAFARI_KWARGS: Keyword args for webdriver.Safari()
-    :var WebDriverConfig.IE_KWARGS: Keyword args for webdriver.Ie()
-    :var WebDriverConfig.EDGE_KWARGS: Keyword args for webdriver.Edge()
-
-    .. note::
-
-        Logging configurations are set when the corresponding ``get_<browser>_driver()``
-        method is called. This allows for projects to override the ``LOG_PATH`` variable
-        without having to also override all ``<browser>_KWARGS`` variables as well.
-
-    Mobile configurations:
-
-    :var WebDriverConfig.CHROME_MOBILE_EMULATION: Dictionary with 'mobileEmulation'
-        options for Chrome
-
-    Headless browser configurations:
-
-    :var WebDriverConfig.CHROME_HEADLESS_ARGS: Command line arguments to use in addition to the --headless flag
-    :var WebDriverConfig.FIREFOX_HEADLESS_ARGS: Command line arguments to use in addition to the -headless flag
-    """
-
+    # Used to set LOG_PATH and SCREENSHOT_PATH. Do not modify!
     _PACKAGE_ROOT = os.path.dirname(os.path.abspath(example_package.__file__))
+
+    # Path to the log directory. Defaults to the log subdirectory in the
+    # webdriver_test_tools package root directory if unspecified
     LOG_PATH = os.path.join(_PACKAGE_ROOT, 'log')
+
+    # Path to the screenshot directory. Defaults to the screenshot subdirectory
+    # in the webdriver_test_tools package root directory if unspecified
     SCREENSHOT_PATH = os.path.join(_PACKAGE_ROOT, 'screenshot')
+
 
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
 
-    # IMPLICIT_WAIT = 0
+    # Browser Driver Initialization Arguments
+    #
+    # NOTE: Logging configurations are set when the corresponding
+    # get_<browser>_driver() method is called. This allows for projects to
+    # override the LOG_PATH variable without having to also override all
+    # <browser>_KWARGS variables as well.
 
+    # Keyword args for webdriver.Firefox()
     # FIREFOX_KWARGS = {}
+
+    # Keyword args for webdriver.Chrome()
     # CHROME_KWARGS = {}
+
+    # Keyword args for webdriver.Safari()
     # SAFARI_KWARGS = {}
+
+    # Keyword args for webdriver.Ie()
     # IE_KWARGS = {}
+
+    # Keyword args for webdriver.Edge()
     # EDGE_KWARGS = {}
 
+
+    # Mobile Configurations
+
+    # Dictionary with 'mobileEmulation' options for Chrome
     # CHROME_MOBILE_EMULATION = { "deviceName": "Pixel 2" }
+
+
+    # Headless Browser Configurations
+
+    # Command line arguments to use in addition to the --headless flag
     # CHROME_HEADLESS_ARGS = ['--window-size=1920x1080',]
+
+    # Command line arguments to use in addition to the -headless flag
     # FIREFOX_HEADLESS_ARGS = []
+
+
+    # Misc Selenium WebDriver Configurations
+
+    # Implicit wait time for webdriver to poll DOM
+    #
+    # NOTE: Documentation says not to mix this with explicit waits and some
+    # instability was noticed when it was set to 10. Projects can override this
+    # if necessary. Implicit wait documentation:
+    # https://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#explicit-and-implicit-waits
+    # IMPLICIT_WAIT = 0
+

--- a/docs/example/example-project/example_package/data.py
+++ b/docs/example/example-project/example_package/data.py
@@ -1,4 +1,3 @@
-
 # Store static data for tests that must use specific values (e.g. emails,
 # usernames, etc). E.g.:
 # REGISTERED_USER_EMAIL = 'registered.user@example.com'

--- a/docs/example/example-project/setup.py
+++ b/docs/example/example-project/setup.py
@@ -7,6 +7,6 @@ setup(
     version='0.1.0',
     packages=find_packages(),
     install_requires=[
-        'webdriver-test-tools>=1.7.1',
+        'webdriver-test-tools>=2.5.0',
         'selenium>=3.11.0',
     ])

--- a/docs/source/browserstack.rst
+++ b/docs/source/browserstack.rst
@@ -8,21 +8,56 @@ Enabling BrowserStack support
 =============================
 
 Testing with BrowserStack can be configured for a project in
-``<test_package>/config/browserstack.py``. To enable BrowserStack support, set
-``BrowserStackConfig.ENABLE`` to ``True`` and set
-``BrowserStackConfig.USERNAME`` and ``BrowserStackConfig.ACCESS_KEY`` to your
-BrowserStack account username and access key respectively. These values can be
-found on the `BrowserStack Automate dashboard
-<https://automate.browserstack.com>`__. 
+``<test_package>/config/browserstack.py``. To enable BrowserStack support, first
+set ``BrowserStackConfig.ENABLE`` to ``True``: 
 
 .. code-block:: python
     :caption: config/browserstack.py
+    :emphasize-lines: 2
 
     class BrowserStackConfig(browserstack.BrowserStackConfig):
         ENABLE = True
-        USERNAME = 'EXAMPLE'
-        ACCESS_KEY = 'EXAMPLEKEY'
+        USERNAME = os.getenv('BROWSERSTACK_USERNAME', '')
+        ACCESS_KEY = os.getenv('BROWSERSTACK_ACCESS_KEY', '')
 
+
+Next, you'll need to set the following environment variables on your machine:
+
+   - ``BROWSERSTACK_USERNAME``: BrowserStack account username
+   - ``BROWSERSTACK_ACCESS_KEY``: The access key for the above account
+
+Both of these values can be found on the `BrowserStack Automate dashboard
+<https://automate.browserstack.com>`__. You can add the following to your
+``.bashrc`` file (replacing ``{USERNAME}`` and ``{ACCESS_KEY}`` with the actual
+values):
+
+.. code-block:: bash
+
+   export BROWSERSTACK_USERNAME='{USERNAME}'
+   export BROWSERSTACK_ACCESS_KEY='{ACCESS_KEY}'
+
+.. note::
+
+   Prior to ``webdriver_test_tools`` 2.5.0, the default ``browserstack.py``
+   generated with ``wtt init`` was set up to store the values of
+   ``BrowserStackConfig.USERNAME`` and ``BrowserStackConfig.ACCESS_KEY`` as
+   string literals, rather than retrieving those values from environment
+   variables. If for whatever reason you don't want to use environment variables
+   for these values, you can just set assign them directly:
+
+   .. code-block:: python
+      :caption: config/browserstack.py
+      :emphasize-lines: 3,4
+
+       class BrowserStackConfig(browserstack.BrowserStackConfig):
+           ENABLE = True
+           USERNAME = '{USERNAME}'
+           ACCESS_KEY = '{ACCESS_KEY}'
+
+   However, it is not recommended to store credentials in a way that might be
+   visible to users who should not have access, so using environment variables
+   would be a more secure approach.
+   
 
 Running tests with BrowserStack
 ===============================

--- a/docs/source/example_project.rst
+++ b/docs/source/example_project.rst
@@ -117,7 +117,7 @@ For this example, we’ll use `example.com <https://www.example.com/>`__.
 .. literalinclude:: ../example/example-project/example_package/config/site.py
     :caption: config/site.py:
     :lines: 1-12
-    :emphasize-lines: 10-11
+    :emphasize-lines: 7,9
 
 
 We’ll be testing that clicking a link takes us to an external page, so we’ll add

--- a/webdriver_test_tools/project/templates/config/browser.py.j2
+++ b/webdriver_test_tools/project/templates/config/browser.py.j2
@@ -3,13 +3,11 @@ from webdriver_test_tools.config import browser
 
 
 class BrowserConfig(browser.BrowserConfig):
-    """Configurations for which browsers to generate tests for
+    """Configurations for which browsers to generate tests for"""
 
-    :var BrowserConfig.ENABLED_BROWSERS: Dictionary mapping browser names to a boolean.
-        True enables the browser, False disables it. Defaults to Chrome and
-        Firefox since they're not platform specific
-    """
-
+    # Dictionary mapping browser names to a boolean. True enables the browser,
+    # False disables it. Defaults to Chrome and Firefox since they're not
+    # platform specific
     ENABLED_BROWSERS = {
         Browsers.FIREFOX: True,
         Browsers.CHROME: True,

--- a/webdriver_test_tools/project/templates/config/browserstack.py.j2
+++ b/webdriver_test_tools/project/templates/config/browserstack.py.j2
@@ -1,29 +1,26 @@
+import os
 from webdriver_test_tools.config import browserstack
 from webdriver_test_tools.testcase.browsers import *
 
 
 class BrowserStackConfig(browserstack.BrowserStackConfig):
-    """Configurations for BrowserStack testing
+    """Configurations for BrowserStack testing"""
 
-    :var BrowserStackConfig.ENABLE: (Default = False) Set to True to enable BrowserStack testing
-    :var BrowserStackConfig.USERNAME: Account username. Required for BrowserStack testing
-    :var BrowserStackConfig.ACCESS_KEY: Access key. Required for BrowserStack testing
-    :var BrowserStackConfig.BS_CAPABILITIES: BrowserStack test configurations
-    :var BrowserStackConfig.ENABLED_BROWSERS: Dictionary mapping browser names to a boolean.
-        True enables the browser, False disables it. Defaults to Chrome and
-        Firefox since they're not platform specific
-    """
+    # Required Configurations
 
+    #: (Default = False) Set to True to enable BrowserStack testing
     ENABLE = False
-    USERNAME = ''
-    ACCESS_KEY = ''
+    #: Account username. Required for BrowserStack testing
+    USERNAME = os.getenv('BROWSERSTACK_USERNAME', '')
+    #: Access key. Required for BrowserStack testing
+    ACCESS_KEY = os.getenv('BROWSERSTACK_ACCESS_KEY', '')
 
-    BS_CAPABILITIES = {
-        'project': '{{ test_package }}',
-        'browserstack.video': False,
-        # 'browserstack.selenium_version': '{{ selenium_version }}',
-    }
 
+    # Browsers
+
+    #: Dictionary mapping browser names to a boolean. True enables the browser,
+    #: False disables it. Defaults to Chrome and Firefox since they're not
+    #: platform specific
     ENABLED_BROWSERS = {
         Browsers.FIREFOX: True,
         Browsers.CHROME: True,
@@ -34,4 +31,12 @@ class BrowserStackConfig(browserstack.BrowserStackConfig):
     }
 
 
+    # Advanced Configurations
+
+    #: BrowserStack test configurations
+    BS_CAPABILITIES = {
+        'project': '{{ test_package }}',
+        'browserstack.video': False,
+        # 'browserstack.selenium_version': '{{ selenium_version }}',
+    }
 

--- a/webdriver_test_tools/project/templates/config/browserstack.py.j2
+++ b/webdriver_test_tools/project/templates/config/browserstack.py.j2
@@ -10,6 +10,7 @@ class BrowserStackConfig(browserstack.BrowserStackConfig):
 
     #: (Default = False) Set to True to enable BrowserStack testing
     ENABLE = False
+    # TODO: Explain environment variables
     #: Account username. Required for BrowserStack testing
     USERNAME = os.getenv('BROWSERSTACK_USERNAME', '')
     #: Access key. Required for BrowserStack testing

--- a/webdriver_test_tools/project/templates/config/browserstack.py.j2
+++ b/webdriver_test_tools/project/templates/config/browserstack.py.j2
@@ -8,20 +8,24 @@ class BrowserStackConfig(browserstack.BrowserStackConfig):
 
     # Required Configurations
 
-    #: (Default = False) Set to True to enable BrowserStack testing
+    # (Default = False) Set to True to enable BrowserStack testing
     ENABLE = False
-    # TODO: Explain environment variables
-    #: Account username. Required for BrowserStack testing
+
+    # Account username. Required for BrowserStack testing.
+    # Uses the value of BROWSERSTACK_USERNAME environment variable by default
     USERNAME = os.getenv('BROWSERSTACK_USERNAME', '')
-    #: Access key. Required for BrowserStack testing
+
+    # Access key. Required for BrowserStack testing.
+    # Uses the value of BROWSERSTACK_ACCESS_KEY environment variable by 
+    # default
     ACCESS_KEY = os.getenv('BROWSERSTACK_ACCESS_KEY', '')
 
 
     # Browsers
 
-    #: Dictionary mapping browser names to a boolean. True enables the browser,
-    #: False disables it. Defaults to Chrome and Firefox since they're not
-    #: platform specific
+    # Dictionary mapping browser names to a boolean. True enables the browser,
+    # False disables it. Defaults to Chrome and Firefox since they're not
+    # platform specific
     ENABLED_BROWSERS = {
         Browsers.FIREFOX: True,
         Browsers.CHROME: True,
@@ -34,7 +38,7 @@ class BrowserStackConfig(browserstack.BrowserStackConfig):
 
     # Advanced Configurations
 
-    #: BrowserStack test configurations
+    # BrowserStack test configurations
     BS_CAPABILITIES = {
         'project': '{{ test_package }}',
         'browserstack.video': False,

--- a/webdriver_test_tools/project/templates/config/site.py.j2
+++ b/webdriver_test_tools/project/templates/config/site.py.j2
@@ -2,11 +2,10 @@ from webdriver_test_tools.config import site
 
 
 class SiteConfig(site.SiteConfig):
-    """URL configurations for a site
-
-    :var SiteConfig.SITE_URL: URL of the home page
-    :var SiteConfig.BASE_URL: Base URL for site pages (followed by a '/')
-    """
+    """URL configurations for a site"""
+    # URL of the home page
     SITE_URL = ''
+    # Base URL for site pages (followed by a '/')
     BASE_URL = ''
+
     # DECLARE ANY OTHER URL VARIABLES NEEDED FOR TESTING HERE

--- a/webdriver_test_tools/project/templates/config/test.py.j2
+++ b/webdriver_test_tools/project/templates/config/test.py.j2
@@ -2,18 +2,20 @@ from webdriver_test_tools.config import test
 
 
 class TestSuiteConfig(test.TestSuiteConfig):
-    """Configurations for test suite
+    """Configurations for test suite"""
 
-    :var TestSuiteConfig.RUNNER_CLASS: ``unittest.TestRunner`` class to use when running
-        tests
-    :var TestSuiteConfig.RUNNER_KWARGS: Dictionary mapping parameter names to desired
-        values used to initialize the ``TestRunner`` configured in :attr:`RUNNER_CLASS`
-    :var TestSuiteConfig.DEFAULT_VERBOSITY: Value used if the ``verbosity`` parameter is
-        unspecified when calling :meth:`get_runner()`.
-    """
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
+
+    # unittest.TestRunner class to use when running tests
     # RUNNER_CLASS = ColourTextTestRunner
+
+    # Dictionary mapping parameter names to desired values used to initialize
+    # the TestRunner configured in RUNNER_CLASS
     # RUNNER_KWARGS = {}
+
+    # Value used if the verbosity parameter is unspecified when calling
+    # get_runner()
     # DEFAULT_VERBOSITY = 2
+
     pass
 

--- a/webdriver_test_tools/project/templates/config/webdriver.py.j2
+++ b/webdriver_test_tools/project/templates/config/webdriver.py.j2
@@ -5,61 +5,70 @@ import {{test_package}}
 
 
 class WebDriverConfig(config.WebDriverConfig):
-    """Configurations for webdriver
+    """Configurations for webdriver"""
 
-    :var WebDriverConfig.LOG_PATH: Path to the log directory. Defaults to the log
-        subdirectory in the webdriver_test_tools package root directory
-    :var WebDriverConfig.SCREENSHOT_PATH: Path to the screenshot directory. Defaults
-        to the screenshot subdirectory in the webdriver_test_tools package root directory
-    :var WebDriverConfig.IMPLICIT_WAIT: Implicit wait time for webdriver to poll DOM
+    # File Path Configurations
 
-        .. note::
-
-            Documentation says not to mix this with explicit waits and some instability
-            was noticed when it was set to 10. Projects can override this if necessary.
-            `Implicit wait documentation
-            <https://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#explicit-and-implicit-waits>`__
-
-    Browser driver initialization arguments:
-
-    :var WebDriverConfig.FIREFOX_KWARGS: Keyword args for webdriver.Firefox()
-    :var WebDriverConfig.CHROME_KWARGS: Keyword args for webdriver.Chrome()
-    :var WebDriverConfig.SAFARI_KWARGS: Keyword args for webdriver.Safari()
-    :var WebDriverConfig.IE_KWARGS: Keyword args for webdriver.Ie()
-    :var WebDriverConfig.EDGE_KWARGS: Keyword args for webdriver.Edge()
-
-    .. note::
-
-        Logging configurations are set when the corresponding ``get_<browser>_driver()``
-        method is called. This allows for projects to override the ``LOG_PATH`` variable
-        without having to also override all ``<browser>_KWARGS`` variables as well.
-
-    Mobile configurations:
-
-    :var WebDriverConfig.CHROME_MOBILE_EMULATION: Dictionary with 'mobileEmulation'
-        options for Chrome
-
-    Headless browser configurations:
-
-    :var WebDriverConfig.CHROME_HEADLESS_ARGS: Command line arguments to use in addition to the --headless flag
-    :var WebDriverConfig.FIREFOX_HEADLESS_ARGS: Command line arguments to use in addition to the -headless flag
-    """
-
+    # Used to set LOG_PATH and SCREENSHOT_PATH. Do not modify!
     _PACKAGE_ROOT = os.path.dirname(os.path.abspath({{test_package}}.__file__))
+
+    # Path to the log directory. Defaults to the log subdirectory in the
+    # webdriver_test_tools package root directory if unspecified
     LOG_PATH = os.path.join(_PACKAGE_ROOT, 'log')
+
+    # Path to the screenshot directory. Defaults to the screenshot subdirectory
+    # in the webdriver_test_tools package root directory if unspecified
     SCREENSHOT_PATH = os.path.join(_PACKAGE_ROOT, 'screenshot')
+
 
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
 
-    # IMPLICIT_WAIT = 0
+    # Browser Driver Initialization Arguments
+    #
+    # NOTE: Logging configurations are set when the corresponding
+    # get_<browser>_driver() method is called. This allows for projects to
+    # override the LOG_PATH variable without having to also override all
+    # <browser>_KWARGS variables as well.
 
+    # Keyword args for webdriver.Firefox()
     # FIREFOX_KWARGS = {}
+
+    # Keyword args for webdriver.Chrome()
     # CHROME_KWARGS = {}
+
+    # Keyword args for webdriver.Safari()
     # SAFARI_KWARGS = {}
+
+    # Keyword args for webdriver.Ie()
     # IE_KWARGS = {}
+
+    # Keyword args for webdriver.Edge()
     # EDGE_KWARGS = {}
 
+
+    # Mobile Configurations
+
+    # Dictionary with 'mobileEmulation' options for Chrome
     # CHROME_MOBILE_EMULATION = { "deviceName": "Pixel 2" }
+
+
+    # Headless Browser Configurations
+
+    # Command line arguments to use in addition to the --headless flag
     # CHROME_HEADLESS_ARGS = ['--window-size=1920x1080',]
+
+    # Command line arguments to use in addition to the -headless flag
     # FIREFOX_HEADLESS_ARGS = []
+
+
+    # Misc Selenium WebDriver Configurations
+
+    # Implicit wait time for webdriver to poll DOM
+    #
+    # NOTE: Documentation says not to mix this with explicit waits and some
+    # instability was noticed when it was set to 10. Projects can override this
+    # if necessary. Implicit wait documentation:
+    # https://www.seleniumhq.org/docs/04_webdriver_advanced.jsp#explicit-and-implicit-waits
+    # IMPLICIT_WAIT = 0
+
 


### PR DESCRIPTION
## Pull Request Description

### Overview

The BrowserStack configs generated with `wtt init` now pull the username and access key from environment variables by default so you don't need to store credentials in string literals.

Additionally, the comments in each config template were cleaned up. Now variable documentation is in-line instead of lumped together at the top in the docstring.

### Details

- The BrowserStack config that is generated with `wtt init` now grabs the username and access key values from `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` environment variables by default
- Re-organized comments in project config file templates so details on each config variable are in an inline comment above the declaration instead of all of the comments being in the docstring
- Updated example project to use new config file layout
- Updated BrowserStack configuration docs to show the new environment variable setup

## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update

