### PR TITLE
base URL assertion update

### DIFF
--- a/webdriver_test_tools/common/utils.py
+++ b/webdriver_test_tools/common/utils.py
@@ -14,6 +14,7 @@ def get_base_url(url):
     current = urlparse(url)
     return current.scheme + '://' + current.netloc + current.path
 
+
 def validate_filename(filename, allow_spaces=False):
     """Strips invalid characters from a filename
 
@@ -33,3 +34,4 @@ def validate_filename(filename, allow_spaces=False):
     """
     regex = r'^-|[^\d\w\. -]' if allow_spaces else r'^-|[^\d\w\.-]'
     return re.sub(regex, '', filename)
+

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -49,6 +49,9 @@ Each of these assertion methods accepts the following optional keyword arguments
 - ``wait_timeout``: (Default = 10) Number of seconds to wait for expected
   conditions to occur before test fails
 
+Some assertions have other optional keyword arguments specific to what they are
+testing. For details, check the documentation for :class:`WebDriverTestCase`.
+
 .. _assertion methods: https://docs.python.org/library/unittest.html#assert-methods
 
 """
@@ -322,8 +325,7 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    # TODO: ignore_trailing_slash
-    def assertBaseUrlChange(self, expected_url, msg=None, wait_timeout=10):
+    def assertBaseUrlChange(self, expected_url, ignore_trailing_slash=True, msg=None, wait_timeout=10):
         """Fail if the URL (ignoring query strings) doesn't match the expected
         URL.
 
@@ -332,12 +334,15 @@ class WebDriverTestCase(unittest.TestCase):
         not match the current URL.
 
         :param expected_url: The expected URL
+        :param ignore_trailing_slash: (Default = True) If True, ignore trailing
+            '/' in the expected url and current base URL when comparing
         :param msg: (Optional) if specified, used as the error message on
             failure
         :param wait_timeout: (Default = 10) Number of seconds to wait for
             expected conditions to occur before test fails
         """
-        if not test.base_url_change_test(self.driver, expected_url, wait_timeout=wait_timeout):
+        if not test.base_url_change_test(self.driver, expected_url,
+                                         ignore_trailing_slash=ignore_trailing_slash, wait_timeout=wait_timeout):
             failure_message = 'Current base URL = {}, expected base URL = {}'.format(
                 utils.get_base_url(self.driver.current_url), expected_url
             )

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -322,6 +322,7 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
+    # TODO: ignore_trailing_slash
     def assertBaseUrlChange(self, expected_url, msg=None, wait_timeout=10):
         """Fail if the URL (ignoring query strings) doesn't match the expected
         URL.

--- a/webdriver_test_tools/webdriver/support/expected_conditions.py
+++ b/webdriver_test_tools/webdriver/support/expected_conditions.py
@@ -65,6 +65,7 @@ class element_to_be_in_view:
         return _is_scrolled_into_view(driver, element, self.fully_in_view)
 
 
+# TODO: update docs
 class base_url_to_be:
     """An expectation for checking the current url, ignoring query strings
     (i.e. strips '?' and everything after it and only looks at the base URL)
@@ -74,12 +75,27 @@ class base_url_to_be:
 
     returns True if the base URL matches, false otherwise
     """
-    def __init__(self, url):
+
+    def __init__(self, url, ignore_trailing_slash=True):
         self.url = url
+        self.ignore_trailing_slash = ignore_trailing_slash
 
     def __call__(self, driver):
         base_url = utils.get_base_url(driver.current_url)
-        return self.url == base_url
+        expected_url = self.url
+        if self.ignore_trailing_slash:
+            expected_url, base_url = self._handle_trailing_slashes(base_url)
+        return expected_url == base_url
+
+    def _handle_trailing_slashes(self, base_url):
+        # TODO: doc
+        return (self._strip_trailing_slash(self.url),
+                self._strip_trailing_slash(base_url))
+
+    def _strip_trailing_slash(self, url):
+        if url.endswith('/'):
+            url = url[:-1]
+        return url
 
 
 # Helper Methods

--- a/webdriver_test_tools/webdriver/support/expected_conditions.py
+++ b/webdriver_test_tools/webdriver/support/expected_conditions.py
@@ -65,13 +65,16 @@ class element_to_be_in_view:
         return _is_scrolled_into_view(driver, element, self.fully_in_view)
 
 
-# TODO: update docs
 class base_url_to_be:
     """An expectation for checking the current url, ignoring query strings
     (i.e. strips '?' and everything after it and only looks at the base URL)
 
     url is the expected URL, which must be an exact match with the current base
     URL
+
+    Optionally accepts the parameter ``ignore_trailing_slash`` (default: True),
+    which will strip any trailing '/' from the expected URL and current base
+    URL before comparing
 
     returns True if the base URL matches, false otherwise
     """
@@ -88,7 +91,14 @@ class base_url_to_be:
         return expected_url == base_url
 
     def _handle_trailing_slashes(self, base_url):
-        # TODO: doc
+        """Utility function to strip trailing '/' from the expected URL and
+        current base URL
+
+        :param base_url: The current URL with any query strings stripped
+
+        :return: A tuple with (``self.url``, ``base_url``) with any trailing
+            '/' removed
+        """
         return (self._strip_trailing_slash(self.url),
                 self._strip_trailing_slash(base_url))
 

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -75,19 +75,20 @@ def url_change_test(driver, expected_url, wait_timeout=10):
     return expected_condition_test(driver, url_checker, wait_timeout)
 
 
-# TODO: ignore_trailing_slash
-def base_url_change_test(driver, expected_url, wait_timeout=10):
+def base_url_change_test(driver, expected_url, ignore_trailing_slash=True, wait_timeout=10):
     """Expected condition test for URL change. Ignores query strings in current url
 
     :param driver: Selenium WebDriver object
     :param expected_url: The expected base URL
+    :param ignore_trailing_slash: (Default = True) If True, ignore trailing '/'
+        in the expected url and current base URL when comparing
     :param wait_timeout: (Default = 10) Number of seconds to wait for expected
         conditions to occur before timing out
 
     :return: True if the current URL (ignoring query strings) matches the expected URL
         before timeout, False otherwise
     """
-    url_checker = customEC.base_url_to_be(expected_url)
+    url_checker = customEC.base_url_to_be(expected_url, ignore_trailing_slash=ignore_trailing_slash)
     return expected_condition_test(driver, url_checker, wait_timeout)
 
 

--- a/webdriver_test_tools/webdriver/support/test.py
+++ b/webdriver_test_tools/webdriver/support/test.py
@@ -75,6 +75,7 @@ def url_change_test(driver, expected_url, wait_timeout=10):
     return expected_condition_test(driver, url_checker, wait_timeout)
 
 
+# TODO: ignore_trailing_slash
 def base_url_change_test(driver, expected_url, wait_timeout=10):
     """Expected condition test for URL change. Ignores query strings in current url
 


### PR DESCRIPTION
## Pull Request Description

### Overview

Added optional parameter `ignore_trailing_slash` to `WebDriverTestCase.assertBaseUrlChange()` (and the associated method and class in `webdriver_test_tools.webdriver.support`). If set to `True` (the default), any trailing '/' in the expected URL or the current base URL will be stripped before comparing the two, e.g. `http://example.com` and `http://example.com/` would be treated as identical.


### Details

#### `testcase` submodule

`WebDriverTestCase`:

- Added optional parameter `ignore_trailing_slash` to `assertBaseUrlChange()` (Default = `True`)


#### `webdriver.support.test`  submodule

- Added optional parameter `ignore_trailing_slash` to `base_url_change_test()` (Default = `True`) 


#### `webdriver.support.expected_conditions`  submodule

`base_url_to_be` expected condition:

- Added `ignore_trailing_slash` parameter to `__init__()`. If set to `True` (the default), trailing '/' characters will be stripped from the expected URL and current base URL before comparing


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update


