### PR TITLE
WebPageObject YAML support and template updates

### DIFF
--- a/docs/example/yaml-example/web_page.yml
+++ b/docs/example/yaml-example/web_page.yml
@@ -1,0 +1,13 @@
+
+# Example 1: Full URL to page
+web_page:
+  url: http://example.com/
+
+# Example 2: Relative to a URL declared in SiteConfig
+web_page:
+  url:
+    # Page path, relative to the SiteConfig attribute specified below
+    path: path/to/page.html
+    # A valid attribute in project SiteConfig to use as the base URL for page
+    relative_to: BASE_URL
+

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -28,6 +28,7 @@ Currently, the following prototype classes support YAML parsing:
 
    * :class:`FormObject <webdriver_test_tools.pageobject.form.FormObject>`
    * :class:`ModalObject <webdriver_test_tools.pageobject.modal.ModalObject>`
+   * :class:`WebPageObject <webdriver_test_tools.pageobject.webpage.WebPageObject>`
 
 YAML support will be added to more in future releases.
 
@@ -81,11 +82,11 @@ Forms
 
 Form objects have 3 required keys:
 
-   * ``form_locator``: `Locator dictionary <Locator Dictionaries>`_ for the
+   * ``form_locator``: :ref:`Locator dictionary <yaml-locators>` for the
      ``<form>`` element
-   * ``submit_locator``: `Locator dictionary <Locator Dictionaries>`_ for the
+   * ``submit_locator``: :ref:`Locator dictionary <yaml-locators>` for the
      form's submit button
-   * ``inputs``: List of form `inputs <Inputs>`_
+   * ``inputs``: List of form :ref:`inputs <yaml-inputs>`
 
 .. _yaml-inputs:
 
@@ -98,7 +99,7 @@ The items in the form ``inputs`` list have the following keys:
      element doesn't have a name attribute, set this to any unique identifier
      (i.e. not used as the ``name`` value for another input in the form)
    * ``input_locator``: **(Required if element has no ``name`` attribute)**
-     `Locator dictionary <Locator Dictionaries>`_ for the element. If provided,
+     :ref:`Locator dictionary <yaml-locators>` for the element. If provided,
      this will be used instead of ``name`` to find the element
    * ``type``: *(Default: ``text``)* The ``type`` attribute of the input
    * ``required``: *(Default: ``true``)* Whether or not the input is required to
@@ -129,14 +130,48 @@ Syntax
 
 Modal objects have 2 required keys:
 
-   * ``modal_locator``: `Locator dictionary <Locator Dictionaries>`_ for the
-     modal container element
-   * ``close_locator``: `Locator dictionary <Locator Dictionaries>`_ for the
-     modal close button
+   * ``modal_locator``: :ref:`Locator dictionary <yaml-locators>` for the modal
+     container element
+   * ``close_locator``: :ref:`Locator dictionary <yaml-locators>` for the modal
+     close button
 
 
 Example
 -------
 
 .. literalinclude:: ../example/yaml-example/modal.yml
+
+
+.. _yaml-web-page-objects:
+
+WebPageObjects
+==============
+
+:class:`WebPageObjects <webdriver_test_tools.pageobject.webpage.WebPageObject>`
+support YAML representations of the modal using the following syntax.
+
+Syntax
+------
+
+Web page objects have one required key ``url``, which can be set to either the
+full URL to the page, or a dictionary containing the following keys:
+
+   * ``path``: The path to the page, relative to the ``SiteConfig`` attribute
+     specified in ``relative_to``
+   * ``relative_to``: A valid attribute declared in the project's ``SiteConfig``
+     class to use as a base URL. It is assumed that the value of this attribute
+     has a trailing '/'
+
+.. note::
+
+   If 'url' is set to just the full URL to the page, the attribute
+   ``PAGE_FILENAME`` will not be set in the ``WebPageObject``. If it is set to a
+   dictionary, ``PAGE_FILENAME`` will be set to the value of 'path'
+
+
+Example
+-------
+
+.. literalinclude:: ../example/yaml-example/web_page.yml
+
 

--- a/webdriver_test_tools/pageobject/webpage.py
+++ b/webdriver_test_tools/pageobject/webpage.py
@@ -18,13 +18,20 @@ class WebPageObject(YAMLParsingPageObject):
     :attr:`YAML_FILE`:
 
     :var WebPageObject.PAGE_FILENAME: File name of the page relative to a base
-        URL declared in ``SITE_CONFIG`` class
+        URL declared in ``SITE_CONFIG`` class.
+
+        .. note::
+
+            If the 'url' key in the YAML file is set to a full URL,
+            :attr:`PAGE_FILENAME` will be set to ``None``
+
     :var WebPageObject.PAGE_URL: Full URL of the page (e.g.
         ``SITE_CONFIG.BASE_URL + PAGE_FILENAME``)
     """
     _YAML_ROOT_KEY = 'web_page'
 
     SITE_CONFIG = None
+
     # TODO: rename to PAGE_RELATIVE_PATH?
     PAGE_FILENAME = None
     PAGE_URL = None
@@ -45,7 +52,6 @@ class WebPageObject(YAMLParsingPageObject):
             # url can be a url string or a dict mapping the page path relative
             # to a SITE_CONFIG attribute
             if isinstance(url, str):
-                # TODO: what about PAGE_FILENAME?
                 self.PAGE_URL = url
             elif isinstance(url, dict):
                 self.PAGE_FILENAME, self.PAGE_URL = self._parse_url_dict(url)
@@ -69,6 +75,7 @@ class WebPageObject(YAMLParsingPageObject):
 
         :raises YAMLKeyError: if ``url`` is missing either required key
         """
+        # TODO: what if URL is an exact attribute in site config and not relative?
         try:
             return (
                 url['path'],

--- a/webdriver_test_tools/pageobject/webpage.py
+++ b/webdriver_test_tools/pageobject/webpage.py
@@ -1,7 +1,8 @@
-from webdriver_test_tools.pageobject import BasePage
+from webdriver_test_tools.pageobject import utils, BasePage, YAMLParsingPageObject
 
 
-class WebPageObject(BasePage):
+# TODO: update docs (include YAML_FILE)
+class WebPageObject(YAMLParsingPageObject):
     """Page object prototype for web pages
 
     :var WebPageObject.PAGE_FILENAME: File name of the page relative to a base
@@ -9,9 +10,44 @@ class WebPageObject(BasePage):
     :var WebPageObject.PAGE_URL: Full URL of the page (e.g.
         ``SiteConfig.BASE_URL + PAGE_FILENAME``)
     """
+    _YAML_ROOT_KEY = 'web_page'
 
+    # TODO: doc and implement
+    SITE_CONFIG = None
+    # TODO: rename to PAGE_RELATIVE_PATH?
     PAGE_FILENAME = None
     PAGE_URL = None
+
+    def parse_yaml(self, file_path):
+        """Parse a YAML representation of the web page object and set
+        attributes accordingly
+
+        See :ref:`YAML WebPageObjects doc <yaml-web-page-objects>` for details
+        on syntax.
+
+        :param file_path: Full path to the YAML file
+        """
+        parsed_yaml = super().parse_yaml(file_path)
+        # Initialize locators
+        try:
+            url = parsed_yaml['url']
+            if isinstance(url, str):
+                # TODO: what about PAGE_FILENAME?
+                self.PAGE_URL = url
+            # TODO: if dict, set attributes accordingly
+            elif isinstance(url, dict):
+                # TODO: key error if either is missing
+                self.PAGE_FILENAME = url['path']
+                # TODO: figure out a way to get project config (self.SITE_CONFIG)
+                relative_to = url['relative_to']
+            else:
+                error_msg = "Invalid 'url' value (url: {}). ".format(url)
+                error_msg += "Must be a string or a dictionary with keys 'path' and 'relative_to'"
+                raise utils.yaml.YAMLValueError(error_msg)
+        except KeyError as e:
+            raise utils.yaml.YAMLKeyError(
+                'Missing required {} key in modal YAML'.format(e)
+            )
 
     def get_page_title(self):
         """Get the title of the current page

--- a/webdriver_test_tools/project/new_file.py
+++ b/webdriver_test_tools/project/new_file.py
@@ -59,7 +59,7 @@ PAGE_OBJECT_TEMPLATE_MAP = {
     },
     WEB_PAGE_PROTOTYPE: {
         'name' : 'web_page_object',
-        'types': ['py']
+        'types': ['py', 'yml']
     },
 }
 

--- a/webdriver_test_tools/project/templates/templates/page_object/form_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/form_object.py.j2
@@ -1,16 +1,9 @@
-{% extends "base_page.py.j2" %}
-
-{% block standard_library_imports %}
-import os
-
-{% endblock %}
+{% extends "yaml_page.py.j2" %}
 
 {% block parent_class %}prototypes.FormObject{% endblock %}
 
 {% block additional_attributes %}
-    # Path to YAML file representing the form object
-    YAML_FILE = os.path.join(os.path.dirname(__file__), '{{module_name}}.yml')
-
+{{super()}}
     # SET THE FOLLOWING ATTRIBUTES TO USE IN FormObject METHODS
 
     # (Optional) Page object of the modal/webpage/etc that should appear on

--- a/webdriver_test_tools/project/templates/templates/page_object/modal_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/modal_object.py.j2
@@ -1,16 +1,9 @@
-{% extends "base_page.py.j2" %}
-
-{% block standard_library_imports %}
-import os
-
-{% endblock %}
+{% extends "yaml_page.py.j2" %}
 
 {% block parent_class %}prototypes.ModalObject{% endblock %}
 
 {% block additional_attributes %}
-    # Path to YAML file representing the modal object
-    YAML_FILE = os.path.join(os.path.dirname(__file__), '{{module_name}}.yml')
-
+{{super()}}
     # SET THE FOLLOWING ATTRIBUTES TO USE IN ModalObject METHODS
 
     # (Optional) Page object of the contents of the modal body. If set to a

--- a/webdriver_test_tools/project/templates/templates/page_object/web_page_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/web_page_object.py.j2
@@ -8,10 +8,14 @@ from {{test_package}}.config import SiteConfig
 {% block parent_class %}prototypes.WebPageObject{% endblock %}
 
 {% block additional_attributes %}
+    # Used for internal WebPageObject methods (do not modify)
+    SITE_CONFIG = SiteConfig
+
+    # TODO: UPDATE FOR YAML
     # File name of the page relative to a base URL declared in SiteConfig
     PAGE_FILENAME = ''
     # Full URL of the page. E.g.:
-    # PAGE_URL = SiteConfig.BASE_URL + PAGE_FILENAME
-    PAGE_URL = SiteConfig.BASE_URL + PAGE_FILENAME
+    # PAGE_URL = SITE_CONFIG.BASE_URL + PAGE_FILENAME
+    PAGE_URL = SITE_CONFIG.BASE_URL + PAGE_FILENAME
 {% endblock %}
 

--- a/webdriver_test_tools/project/templates/templates/page_object/web_page_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/web_page_object.py.j2
@@ -1,4 +1,4 @@
-{% extends "base_page.py.j2" %}
+{% extends "yaml_page.py.j2" %}
 
 {% block additional_imports %}
 
@@ -8,14 +8,8 @@ from {{test_package}}.config import SiteConfig
 {% block parent_class %}prototypes.WebPageObject{% endblock %}
 
 {% block additional_attributes %}
+{{super()}}
     # Used for internal WebPageObject methods (do not modify)
     SITE_CONFIG = SiteConfig
-
-    # TODO: UPDATE FOR YAML
-    # File name of the page relative to a base URL declared in SiteConfig
-    PAGE_FILENAME = ''
-    # Full URL of the page. E.g.:
-    # PAGE_URL = SITE_CONFIG.BASE_URL + PAGE_FILENAME
-    PAGE_URL = SITE_CONFIG.BASE_URL + PAGE_FILENAME
 {% endblock %}
 

--- a/webdriver_test_tools/project/templates/templates/page_object/web_page_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/web_page_object.yml.j2
@@ -1,0 +1,18 @@
+# WebPageObject YAML Documentation: 
+# https://connordelacruz.com/webdriver-test-tools/yaml.html#webpageobjects
+
+# SET url KEY BELOW:
+
+web_page:
+  # REQIRED: URL to the page. The following formats are accepted:
+  # 
+  # # Full URL to the page
+  # url: http://example.com/
+  #
+  # url:
+  #   # Page path, relative to the SiteConfig attribute specified below
+  #   path: path/to/page.html
+  #   # A valid attribute in project SiteConfig to use as the base URL for the page
+  #   relative_to: BASE_URL
+  url:
+

--- a/webdriver_test_tools/project/templates/templates/page_object/yaml_page.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/yaml_page.py.j2
@@ -1,0 +1,12 @@
+{% extends "base_page.py.j2" %}
+
+{% block standard_library_imports %}
+import os
+
+{% endblock %}
+
+{% block additional_attributes %}
+    # Path to YAML file representing the object
+    YAML_FILE = os.path.join(os.path.dirname(__file__), '{{module_name}}.yml')
+{% endblock %}
+


### PR DESCRIPTION
## Pull Request Description

### Overview

* Added YAML parsing support for `WebPageObject`
* Extracted common template items to `yaml_page.py.j2` and updated existing templates to extend it


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)


## Additional Comments

Using new branch `page-object-yaml` as a base. Since it's less useful to have YAML for `WebPageObject` (it has one key and part of its syntax is dependent on Python objects anyway), I want to make YAML parsing optional and more configurable before merging this into main branches

