### PR TITLE
NavObject YAML support

### DIFF
--- a/docs/example/yaml-example/collapsible_nav.yml
+++ b/docs/example/yaml-example/collapsible_nav.yml
@@ -1,0 +1,58 @@
+# Example 2: Collapsible navbar
+nav:
+  collapsible: true
+  # REQUIRED: Locator for the collapsible menu element
+  menu_locator:
+    by: ID
+    locator: nav-menu
+  # REQUIRED: Locator for the button that collapses the nav menu
+  expand_button_locator:
+    by: ID
+    locator: navbar-toggle
+  # Expand and collapse button are the same in this example
+  # collapse_button_locator:
+  #   by: <BY>
+  #   locator: <LOCATOR>
+  links:
+    # Page link
+    - name: home
+      link_locator:
+        by: CLASS_NAME
+        locator: navbar-brand
+      target:
+        path: index.html
+        relative_to: BASE_URL
+    # Section link
+    - name: section1
+      link_locator:
+        by: CSS_SELECTOR
+        locator: 'a[href="#section1"]'
+      click: section
+      target: '#section1'
+    # Dropdown menu
+    - name: click-menu
+      link_locator:
+        by: ID
+        locator: click-menu-link
+      click: menu
+      menu:
+        menu_locator:
+          by: ID
+          locator: click-menu
+        # Dropdown menu links
+        links:
+          - name: page1
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="page1.html"]'
+            target:
+              path: page1.html
+              relative_to: BASE_URL
+          - name: page2
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="page2.html"]'
+            target:
+              path: page2.html
+              relative_to: BASE_URL
+

--- a/docs/example/yaml-example/nav.yml
+++ b/docs/example/yaml-example/nav.yml
@@ -1,0 +1,76 @@
+# Example 1: Standard navbar
+nav:
+  # (Default: true) Whether the navbar is fixed to the window.
+  fixed: false
+  links:
+    # Page link
+    - name: home
+      link_locator:
+        by: CLASS_NAME
+        locator: navbar-brand
+      target:
+        path: index.html
+        relative_to: BASE_URL
+    # Section link
+    - name: section1
+      link_locator:
+        by: CSS_SELECTOR
+        locator: 'a[href="#section1"]'
+      click: section
+      target: '#section1'
+    # Dropdown menu (hover)
+    - name: hover-menu
+      link_locator:
+        by: ID
+        locator: hover-menu-link
+      # Set click action to 'none', hover to 'menu'
+      click: none
+      hover: menu
+      menu:
+        menu_locator:
+          by: ID
+          locator: hover-menu
+        # Dropdown menu links (same syntax as nav links)
+        links:
+          - name: page1
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#hover-menu a[href="page1.html"]'
+            target:
+              path: page1.html
+              relative_to: BASE_URL
+          - name: page2
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#hover-menu a[href="page2.html"]'
+            target:
+              path: page2.html
+              relative_to: BASE_URL
+    # Dropdown menu (click)
+    - name: click-menu
+      link_locator:
+        by: ID
+        locator: click-menu-link
+      # Set click action to 'menu'
+      click: menu
+      menu:
+        menu_locator:
+          by: ID
+          locator: click-menu
+        # Dropdown menu links
+        links:
+          - name: page1
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="page1.html"]'
+            target:
+              path: page1.html
+              relative_to: BASE_URL
+          - name: page2
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="page2.html"]'
+            target:
+              path: page2.html
+              relative_to: BASE_URL
+

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -304,5 +304,7 @@ The items in the nav ``links`` list have the following keys:
 Example
 -------
 
-.. todo normal and collapsible examples
+.. literalinclude:: ../example/yaml-example/nav.yml
+
+.. literalinclude:: ../example/yaml-example/collapsible_nav.yml
 

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -24,14 +24,14 @@ see `Ansible's YAML documentation`_.
 Supported Prototype Classes
 ---------------------------
 
-.. todo Is this section necessary?
+.. todo Is this section necessary now that all prototypes are supported?
 
-Currently, the following prototype classes support YAML parsing:  
+The following prototype classes support YAML parsing:  
 
    * :class:`FormObject <webdriver_test_tools.pageobject.form.FormObject>`
    * :class:`ModalObject <webdriver_test_tools.pageobject.modal.ModalObject>`
-   * :class:`WebPageObject <webdriver_test_tools.pageobject.webpage.WebPageObject>`
    * :class:`NavObject <webdriver_test_tools.pageobject.nav.NavObject>`
+   * :class:`WebPageObject <webdriver_test_tools.pageobject.webpage.WebPageObject>`
 
 
 Configure Defaults
@@ -194,33 +194,6 @@ Example
 .. literalinclude:: ../example/yaml-example/modal.yml
 
 
-.. _yaml-web-page-objects:
-
-WebPageObjects
-==============
-
-:class:`WebPageObjects <webdriver_test_tools.pageobject.webpage.WebPageObject>`
-support YAML representations of the modal using the following syntax.
-
-Syntax
-------
-
-Web page objects have one required key ``url``, which can be set to either the
-full URL to the page or a :ref:`relative URL dictionary <yaml-relative-urls>`
-
-.. note::
-
-   If 'url' is set to just the full URL to the page, the attribute
-   ``PAGE_FILENAME`` will not be set in the ``WebPageObject``. If it is set to a
-   dictionary, ``PAGE_FILENAME`` will be set to the value of 'path'
-
-
-Example
--------
-
-.. literalinclude:: ../example/yaml-example/web_page.yml
-
-
 .. _yaml-nav-objects:
 
 NavObjects
@@ -306,4 +279,31 @@ Example
 .. literalinclude:: ../example/yaml-example/nav.yml
 
 .. literalinclude:: ../example/yaml-example/collapsible_nav.yml
+
+
+.. _yaml-web-page-objects:
+
+WebPageObjects
+==============
+
+:class:`WebPageObjects <webdriver_test_tools.pageobject.webpage.WebPageObject>`
+support YAML representations of the modal using the following syntax.
+
+Syntax
+------
+
+Web page objects have one required key ``url``, which can be set to either the
+full URL to the page or a :ref:`relative URL dictionary <yaml-relative-urls>`
+
+.. note::
+
+   If 'url' is set to just the full URL to the page, the attribute
+   ``PAGE_FILENAME`` will not be set in the ``WebPageObject``. If it is set to a
+   dictionary, ``PAGE_FILENAME`` will be set to the value of 'path'
+
+
+Example
+-------
+
+.. literalinclude:: ../example/yaml-example/web_page.yml
 

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -280,6 +280,8 @@ The items in the nav ``links`` list have the following keys:
       * (``click: section``) The ``id`` attribute of the section element (i.e.
         the link's ``href`` attribute)
 
+   .. _yaml-nav-menus:
+
    * ``menu``: **(Required if** ``click`` **or** ``hover`` **is** ``menu`` **)**
      A dictionary representing the menu that appears on click or hover. Contains
      the following **required** keys:

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -92,6 +92,8 @@ required keys:
      strategy
 
 
+.. todo document root keys for each
+
 .. _yaml-form-objects:
 
 FormObjects
@@ -202,4 +204,83 @@ Example
 
 .. literalinclude:: ../example/yaml-example/web_page.yml
 
+
+.. _yaml-nav-objects:
+
+NavObjects
+==========
+
+:class:`NavObjects <webdriver_test_tools.pageobject.nav.NavObject>` support YAML
+representations of the nav using the following syntax.
+
+Syntax
+------
+
+.. _yaml-navs:
+
+Navbars
+~~~~~~~
+
+Navbar objects have the following keys: 
+
+   * ``links``: **(Required)** List of :ref:`links <yaml-links>`.
+   * ``fixed``: *(Default:* ``true`` *)* Whether or not the navbar is fixed to
+     the screen
+   .. todo collapsible stuff
+
+.. _yaml-links:
+
+Links
+~~~~~
+
+The items in the nav ``links`` list have the following keys:
+
+   * ``name``: **(Required)** Name used to refer to this link. Must be unique
+     from other links in the same list
+   * ``link_locator``: **(Required)** :ref:`Locator dictionary <yaml-locators>`
+     for the link element
+   * ``click``: *(Default:* ``page`` *)* One of the following values describing
+     the expected action on click:
+
+      * ``page``: *(Default)* Go to another page
+      * ``section``: Jump to a section in the current page
+      * ``menu``: Toggle a dropdown menu
+      * ``none``: No expected action
+
+   * ``hover``: *(Default:* ``none`` *)* One of the following values describing
+     the expected action on hover:
+
+      * ``none``: *(Default)* No expected action
+      * ``menu``: Show dropdown menu
+
+   * ``target``: **(Required if** ``click`` **is** ``page`` **or** ``section``
+     **)** The link target, formatted in one of the following ways (depending on
+     ``click`` type):
+
+      * (``click: page``) The full URL to the target page
+      * (``click: page``) A dictionary containing the following keys:
+
+         * ``path``: The path to the target page, relative to the ``SiteConfig``
+           attribute specified in ``relative_to``
+         * ``relative_to``: A valid attribute declared in the project's
+           ``SiteConfig`` class to use as a base URL. It is assumed that the
+           value of this attribute has a trailing '/'
+
+      * (``click: section``) The ``id`` attribute of the section element (i.e.
+        the link's ``href`` attribute)
+
+   * ``menu``: **(Required if** ``click`` **or** ``hover`` **is** ``menu`` **)**
+     A dictionary representing the menu that appears on click or hover. Contains
+     the following **required** keys:
+
+      * ``menu_locator``: :ref:`Locator dictionary <yaml-locators>` for the menu
+        element
+      * ``links``: List of :ref:`links <yaml-links>`. Same syntax as the nav
+        object links list
+
+
+Example
+-------
+
+.. todo
 

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -24,15 +24,14 @@ see `Ansible's YAML documentation`_.
 Supported Prototype Classes
 ---------------------------
 
+.. todo Is this section necessary?
+
 Currently, the following prototype classes support YAML parsing:  
 
    * :class:`FormObject <webdriver_test_tools.pageobject.form.FormObject>`
    * :class:`ModalObject <webdriver_test_tools.pageobject.modal.ModalObject>`
    * :class:`WebPageObject <webdriver_test_tools.pageobject.webpage.WebPageObject>`
    * :class:`NavObject <webdriver_test_tools.pageobject.nav.NavObject>`
-
-.. todo remove this comment after finishing nav objects
-YAML support will be added to more in future releases.
 
 
 Configure Defaults

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -29,7 +29,9 @@ Currently, the following prototype classes support YAML parsing:
    * :class:`FormObject <webdriver_test_tools.pageobject.form.FormObject>`
    * :class:`ModalObject <webdriver_test_tools.pageobject.modal.ModalObject>`
    * :class:`WebPageObject <webdriver_test_tools.pageobject.webpage.WebPageObject>`
+   * :class:`NavObject <webdriver_test_tools.pageobject.nav.NavObject>`
 
+.. todo remove this comment after finishing nav objects
 YAML support will be added to more in future releases.
 
 
@@ -90,6 +92,27 @@ required keys:
 
    * ``locator``: Value used to locate element with the specified locator
      strategy
+
+
+.. _yaml-relative-urls:
+
+Relative URL Dictionaries
+-------------------------
+
+URLs that are relative to attributes specified in a project's ``SiteConfig`` are
+specified with dictionaries using the following keys:
+
+   * ``path``: The path to the page, relative to the ``SiteConfig`` attribute
+     specified in ``relative_to``
+   * ``relative_to``: A valid attribute declared in the project's ``SiteConfig``
+     class to use as a base URL
+
+.. note::
+
+   Internally, these URL dictionaries are parsed using
+   :meth:`SiteConfig.parse_relative_url_dict`. If the attribute that
+   ``relative_to`` specifies does not have a trailing '/', this method adds one
+   before building the full URL
 
 
 .. todo document root keys for each
@@ -184,13 +207,7 @@ Syntax
 ------
 
 Web page objects have one required key ``url``, which can be set to either the
-full URL to the page, or a dictionary containing the following keys:
-
-   * ``path``: The path to the page, relative to the ``SiteConfig`` attribute
-     specified in ``relative_to``
-   * ``relative_to``: A valid attribute declared in the project's ``SiteConfig``
-     class to use as a base URL. It is assumed that the value of this attribute
-     has a trailing '/'
+full URL to the page or a :ref:`relative URL dictionary <yaml-relative-urls>`
 
 .. note::
 
@@ -258,14 +275,8 @@ The items in the nav ``links`` list have the following keys:
      ``click`` type):
 
       * (``click: page``) The full URL to the target page
-      * (``click: page``) A dictionary containing the following keys:
-
-         * ``path``: The path to the target page, relative to the ``SiteConfig``
-           attribute specified in ``relative_to``
-         * ``relative_to``: A valid attribute declared in the project's
-           ``SiteConfig`` class to use as a base URL. It is assumed that the
-           value of this attribute has a trailing '/'
-
+      * (``click: page``) :ref:`Relative URL dictionary <yaml-relative-urls>`
+        with the path to the target page
       * (``click: section``) The ``id`` attribute of the section element (i.e.
         the link's ``href`` attribute)
 

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -243,7 +243,16 @@ Navbar objects have the following keys:
    * ``links``: **(Required)** List of :ref:`links <yaml-links>`.
    * ``fixed``: *(Default:* ``true`` *)* Whether or not the navbar is fixed to
      the screen
-   .. todo collapsible stuff
+   * ``collapsible``: *(Default:* ``false`` *)* Whether or not the navbar is
+     collapsible (e.g. for hamburger menus)
+   * ``menu_locator``: **(Required if** ``collapsible`` **is** ``true`` **)**
+     :ref:`Locator dictionary <yaml-locators>` for the collapsible menu element
+   * ``expand_button_locator``: **(Required if** ``collapsible`` **is** ``true`` **)**
+     :ref:`Locator dictionary <yaml-locators>` for the button that expands the
+     menu
+   * ``collapse_button_locator`` *(Optional)* Locator for the button that
+     collapses the menu. Only needed if ``collapsible`` is ``true`` and the
+     collapse button isn't the same as the expand button
 
 .. _yaml-links:
 
@@ -295,5 +304,5 @@ The items in the nav ``links`` list have the following keys:
 Example
 -------
 
-.. todo
+.. todo normal and collapsible examples
 

--- a/test/html/collapsible_navbar.html
+++ b/test/html/collapsible_navbar.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <title>Navbar</title>
+
+    <link rel="stylesheet" href="res/css/bootstrap.min.css">
+    <link rel="stylesheet" href="res/css/navbar.css">
+
+  </head>
+  <body>
+
+    <nav class="navbar bg-light">
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle" id="navbar-toggle" data-toggle="collapse" data-target="#nav-menu">
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span> 
+        </button>
+        <a class="navbar-brand" href="index.html">Home</a>
+      </div>
+      <div class="collapse navbar-collapse" id="nav-menu">
+        <ul class="nav navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="#section1">Section 1</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#section2">Section 2</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#section3">Section 3</a>
+          </li>
+          <li class="dropdown">
+            <a class="dropdown-toggle nav-link" id="click-menu-link" 
+               data-toggle="dropdown" href="#" aria-expanded="false">
+              Dropdown (Click)<span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu" id="click-menu">
+              <li><a href="index.html">Home</a></li>
+              <li><a href="form.html">Form</a></li>
+              <li><a href="modal.html">Modal</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="jumbotron jumbotron-fluid">
+      <div class="container">
+        <h1 class="display-4">Navbar Test Page</h1>
+      </div>
+    </div>
+
+    <div class="container-fluid">
+
+      <div class="container my-5" id="section1">
+        <h2>Section 1</h2>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+
+        Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+
+        Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
+        </p>
+        <p>
+        <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
+        </p>
+      </div>
+
+      <div class="container my-5" id="section2">
+        <h2>Section 2</h2>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+
+        Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+
+        Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
+        </p>
+        <p>
+        <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
+        </p>
+      </div>
+
+      <div class="container my-5" id="section3">
+        <h2>Section 3</h2>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+
+        Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+
+        Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
+        </p>
+        <p>
+        <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
+        </p>
+      </div>
+
+    </div>
+
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
+            integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"
+            integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
+            crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+            integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
+            crossorigin="anonymous"></script>
+
+  </body>
+</html>

--- a/test/html/navbar.html
+++ b/test/html/navbar.html
@@ -32,6 +32,17 @@
             <li class="nav-item">
                 <a class="nav-link" href="#section3">Section 3</a>
             </li>
+            <!-- TODO: add hover -->
+            <li class="dropdown">
+              <a class="dropdown-toggle nav-link" data-toggle="dropdown" href="#" aria-expanded="false">
+                Dropdown<span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <li><a href="#">Page 1-1</a></li>
+                <li><a href="#">Page 1-2</a></li>
+                <li><a href="#">Page 1-3</a></li>
+              </ul>
+            </li>
         </ul>
     </nav>
 

--- a/test/html/navbar.html
+++ b/test/html/navbar.html
@@ -7,6 +7,7 @@
     <title>Navbar</title>
 
     <link rel="stylesheet" href="res/css/bootstrap.min.css">
+    <link rel="stylesheet" href="res/css/navbar.css">
 
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
             integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
@@ -33,7 +34,16 @@
             <li class="nav-item">
                 <a class="nav-link" href="#section3">Section 3</a>
             </li>
-            <!-- TODO: hover dropdown -->
+            <li class="dropdown hover-dropdown">
+              <a class="dropdown-toggle nav-link" id="hover-menu-link" href="#">
+                Dropdown (Hover)<span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" id="click-menu">
+                <li><a href="#">Page 1-1</a></li>
+                <li><a href="#">Page 1-2</a></li>
+                <li><a href="#">Page 1-3</a></li>
+              </ul>
+            </li>
             <li class="dropdown">
               <a class="dropdown-toggle nav-link" id="click-menu-link" data-toggle="dropdown" href="#" aria-expanded="false">
                 Dropdown (Click)<span class="caret"></span>

--- a/test/html/navbar.html
+++ b/test/html/navbar.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
@@ -19,95 +19,98 @@
             integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
             crossorigin="anonymous"></script>
 
-</head>
-<body>
+  </head>
+  <body>
 
     <nav class="navbar navbar-expand bg-light">
-        <ul class="navbar-nav">
-            <!-- TODO: page links -->
-            <li class="nav-item">
-                <a class="nav-link" href="#section1">Section 1</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="#section2">Section 2</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" href="#section3">Section 3</a>
-            </li>
-            <li class="dropdown hover-dropdown">
-              <a class="dropdown-toggle nav-link" id="hover-menu-link" href="#">
-                Dropdown (Hover)<span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu" id="click-menu">
-                <li><a href="#">Page 1-1</a></li>
-                <li><a href="#">Page 1-2</a></li>
-                <li><a href="#">Page 1-3</a></li>
-              </ul>
-            </li>
-            <li class="dropdown">
-              <a class="dropdown-toggle nav-link" id="click-menu-link" data-toggle="dropdown" href="#" aria-expanded="false">
-                Dropdown (Click)<span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu" id="click-menu">
-                <li><a href="#">Page 1-1</a></li>
-                <li><a href="#">Page 1-2</a></li>
-                <li><a href="#">Page 1-3</a></li>
-              </ul>
-            </li>
-        </ul>
+      <div class="navbar-header">
+        <a class="navbar-brand" href="index.html">Home</a>
+      </div>
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="#section1">Section 1</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#section2">Section 2</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#section3">Section 3</a>
+        </li>
+        <li class="dropdown hover-dropdown">
+          <a class="dropdown-toggle nav-link" id="hover-menu-link" href="#">
+            Dropdown (Hover)<span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" id="hover-menu">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="form.html">Form</a></li>
+            <li><a href="modal.html">Modal</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a class="dropdown-toggle nav-link" id="click-menu-link" 
+             data-toggle="dropdown" href="#" aria-expanded="false">
+            Dropdown (Click)<span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" id="click-menu">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="form.html">Form</a></li>
+            <li><a href="modal.html">Modal</a></li>
+          </ul>
+        </li>
+      </ul>
     </nav>
 
     <div class="jumbotron jumbotron-fluid">
-        <div class="container">
-            <h1 class="display-4">Navbar Test Page</h1>
-        </div>
+      <div class="container">
+        <h1 class="display-4">Navbar Test Page</h1>
+      </div>
     </div>
 
     <div class="container-fluid">
 
-        <div class="container my-5" id="section1">
-            <h2>Section 1</h2>
-            <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+      <div class="container my-5" id="section1">
+        <h2>Section 1</h2>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
 
-            Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+        Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
 
-            Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
-            </p>
-            <p>
-            <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
-            </p>
-        </div>
+        Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
+        </p>
+        <p>
+        <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
+        </p>
+      </div>
 
-        <div class="container my-5" id="section2">
-            <h2>Section 2</h2>
-            <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+      <div class="container my-5" id="section2">
+        <h2>Section 2</h2>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
 
-            Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+        Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
 
-            Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
-            </p>
-            <p>
-            <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
-            </p>
-        </div>
+        Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
+        </p>
+        <p>
+        <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
+        </p>
+      </div>
 
-        <div class="container my-5" id="section3">
-            <h2>Section 3</h2>
-            <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+      <div class="container my-5" id="section3">
+        <h2>Section 3</h2>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
 
-            Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+        Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
 
-            Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
-            </p>
-            <p>
-            <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
-            </p>
-        </div>
+        Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
+        </p>
+        <p>
+        <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
+        </p>
+      </div>
 
     </div>
 
-</body>
+  </body>
 </html>

--- a/test/html/navbar.html
+++ b/test/html/navbar.html
@@ -23,6 +23,7 @@
 
     <nav class="navbar navbar-expand bg-light">
         <ul class="navbar-nav">
+            <!-- TODO: page links -->
             <li class="nav-item">
                 <a class="nav-link" href="#section1">Section 1</a>
             </li>
@@ -32,12 +33,12 @@
             <li class="nav-item">
                 <a class="nav-link" href="#section3">Section 3</a>
             </li>
-            <!-- TODO: add hover -->
+            <!-- TODO: hover dropdown -->
             <li class="dropdown">
-              <a class="dropdown-toggle nav-link" data-toggle="dropdown" href="#" aria-expanded="false">
-                Dropdown<span class="caret"></span>
+              <a class="dropdown-toggle nav-link" id="click-menu-link" data-toggle="dropdown" href="#" aria-expanded="false">
+                Dropdown (Click)<span class="caret"></span>
               </a>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu" id="click-menu">
                 <li><a href="#">Page 1-1</a></li>
                 <li><a href="#">Page 1-2</a></li>
                 <li><a href="#">Page 1-3</a></li>
@@ -57,7 +58,11 @@
         <div class="container my-5" id="section1">
             <h2>Section 1</h2>
             <p>
-            Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+
+            Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+
+            Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
             </p>
             <p>
             <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
@@ -67,7 +72,11 @@
         <div class="container my-5" id="section2">
             <h2>Section 2</h2>
             <p>
-            Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+
+            Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+
+            Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
             </p>
             <p>
             <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>
@@ -77,7 +86,11 @@
         <div class="container my-5" id="section3">
             <h2>Section 3</h2>
             <p>
-            Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Incommoda autem et commoda-ita enim estmata et dustmata appello-communia esse voluerunt, paria noluerunt. Ergo id est convenienter naturae vivere, a natura discedere. Re mihi non aeque satisfacit, et quidem locis pluribus. Eam tum adesse, cum dolor omnis absit; Ut proverbia non nulla veriora sint quam vestra dogmata. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. In his igitur partibus duabus nihil erat, quod Zeno commutare gestiret. Illa tamen simplicia, vestra versuta. Duo Reges: constructio interrete. Quem si tenueris, non modo meum Ciceronem, sed etiam me ipsum abducas licebit. 
+
+            Sed vos squalidius, illorum vides quam niteat oratio. Quid, quod homines infima fortuna, nulla spe rerum gerendarum, opifices denique delectantur historia? Ita multo sanguine profuso in laetitia et in victoria est mortuus. Nam si beatus umquam fuisset, beatam vitam usque ad illum a Cyro extructum rogum pertulisset. Illud non continuo, ut aeque incontentae. 
+
+            Sed residamus, inquit, si placet. Faceres tu quidem, Torquate, haec omnia; Urgent tamen et nihil remittunt. Huius ego nunc auctoritatem sequens idem faciam. Nec enim, dum metuit, iustus est, et certe, si metuere destiterit, non erit; Cupit enim dcere nihil posse ad beatam vitam deesse sapienti. Age sane, inquam.
             </p>
             <p>
             <a class="btn btn-secondary" href="#" role="button">View details &raquo;</a>

--- a/test/html/res/css/navbar.css
+++ b/test/html/res/css/navbar.css
@@ -1,0 +1,6 @@
+/* Custom navbar styles */
+
+.hover-dropdown:hover .dropdown-menu {
+    display: block;
+}
+

--- a/test/html/res/css/navbar.css
+++ b/test/html/res/css/navbar.css
@@ -3,4 +3,7 @@
 .hover-dropdown:hover .dropdown-menu {
     display: block;
 }
-
+.collapsing {
+    /* Fix false positives caused by animations */
+    transition: height .05s ease;
+}

--- a/test/page-object-tests/page_object_tests/pages/no_yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/no_yaml_nav.py
@@ -1,0 +1,154 @@
+from selenium.webdriver.common.by import By
+from webdriver_test_tools.pageobject import *
+from webdriver_test_tools.webdriver import actions, locate
+
+from page_object_tests.config import SiteConfig
+
+
+class NoYAMLNavObject(prototypes.NavObject):
+
+    class Locator:
+        """WebDriver locator tuples for any elements that will need to be
+        accessed by this page object.
+        """
+        pass
+
+    # Used for internal methods (do not modify)
+    SITE_CONFIG = SiteConfig
+
+    # SET THE FOLLOWING ATTRIBUTES TO USE IN NavObject METHODS
+
+    # REQUIRED: List of link dictionaries. These will be used to initialize
+    # NavLinkObject instances at runtime.
+    # Dictionaries use same keys as YAML links. For syntax, see:
+    # https://connordelacruz.com/webdriver-test-tools/yaml.html#yaml-links
+    LINK_DICTS = [
+        {
+            'name': 'home',
+            'link_locator': {
+                'by': 'CLASS_NAME', 'locator': 'navbar-brand'
+            },
+            'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+        },
+        {
+            'name': 'section3',
+            'link_locator': {
+                'by': 'CSS_SELECTOR', 'locator': 'a[href="#section3"]'
+            },
+            'click': 'section',
+            'target': '#section3'
+        },
+        {
+            'name': 'hover-menu',
+            'link_locator': {
+                'by': 'ID', 'locator': 'hover-menu-link'
+            },
+            'click': 'none',
+            'hover': 'menu',
+            'menu': {
+                'menu_locator': {
+                    'by': 'ID', 'locator': 'hover-menu'
+                },
+                'links': [
+                    {
+                        'name': 'home',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#hover-menu a[href="index.html"]'
+                        },
+                        'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+                    },
+                    {
+                        'name': 'form',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#hover-menu a[href="form.html"]'
+                        },
+                        'target': {'path': 'form.html', 'relative_to': 'BASE_URL'}
+                    },
+                    {
+                        'name': 'modal',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#hover-menu a[href="modal.html"]'
+                        },
+                        'target': {'path': 'modal.html', 'relative_to': 'BASE_URL'}
+                    },
+                ]
+            }
+        },
+        {
+            'name': 'click-menu',
+            'link_locator': {
+                'by': 'ID', 'locator': 'click-menu-link'
+            },
+            'click': 'menu',
+            'menu': {
+                'menu_locator': {
+                    'by': 'ID', 'locator': 'click-menu'
+                },
+                'links': [
+                    {
+                        'name': 'home',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="index.html"]'
+                        },
+                        'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+                    },
+                    {
+                        'name': 'form',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="form.html"]'
+                        },
+                        'target': {'path': 'form.html', 'relative_to': 'BASE_URL'}
+                    },
+                    {
+                        'name': 'modal',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="modal.html"]'
+                        },
+                        'target': {'path': 'modal.html', 'relative_to': 'BASE_URL'}
+                    },
+                ]
+            }
+        },
+    ]
+
+    # UNCOMMENT BELOW TO OVERRIDE NavObject DEFAULTS
+
+    # (Default = True) True if element is a fixed navbar, False otherwise. If
+    # set to False, click_page_link() and hover_over_page_link() will scroll
+    # the target link into view before interacting with it
+    FIXED = False
+
+
+class NoYAMLCollapsibleNavObject(prototypes.NavObject):
+
+    class Locator:
+        """WebDriver locator tuples for any elements that will need to be
+        accessed by this page object.
+        """
+        pass
+
+    # Used for internal methods (do not modify)
+    SITE_CONFIG = SiteConfig
+
+    # SET THE FOLLOWING ATTRIBUTES TO USE IN NavObject METHODS
+
+    # REQUIRED: List of link dictionaries. These will be used to initialize
+    # NavLinkObject instances at runtime.
+    # Dictionaries use same keys as YAML links. For syntax, see:
+    # https://connordelacruz.com/webdriver-test-tools/yaml.html#yaml-links
+    LINK_DICTS = []
+    # REQUIRED: Locator for the collapsible menu element
+    MENU_LOCATOR = None
+    # REQUIRED: Locator for the button that expands the nav menu
+    EXPAND_BUTTON_LOCATOR = None
+    # (Optional) Locator for the button that collapses the nav menu.
+    # If not set, the value from EXPAND_BUTTON_LOCATOR will be used
+    COLLAPSE_BUTTON_LOCATOR = None
+
+    # UNCOMMENT BELOW TO OVERRIDE NavObject DEFAULTS
+
+    # (Default = True) True if element is a fixed navbar, False otherwise. If
+    # set to False, click_page_link() and hover_over_page_link() will scroll
+    # the target link into view before interacting with it
+    # FIXED = True
+

--- a/test/page-object-tests/page_object_tests/pages/no_yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/no_yaml_nav.py
@@ -136,11 +136,64 @@ class NoYAMLCollapsibleNavObject(prototypes.NavObject):
     # NavLinkObject instances at runtime.
     # Dictionaries use same keys as YAML links. For syntax, see:
     # https://connordelacruz.com/webdriver-test-tools/yaml.html#yaml-links
-    LINK_DICTS = []
+    LINK_DICTS = [
+        {
+            'name': 'home',
+            'link_locator': {
+                'by': 'CLASS_NAME', 'locator': 'navbar-brand'
+            },
+            'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+        },
+        {
+            'name': 'section3',
+            'link_locator': {
+                'by': 'CSS_SELECTOR', 'locator': 'a[href="#section3"]'
+            },
+            'click': 'section',
+            'target': '#section3'
+        },
+        {
+            'name': 'click-menu',
+            'link_locator': {
+                'by': 'ID', 'locator': 'click-menu-link'
+            },
+            'click': 'menu',
+            'menu': {
+                'menu_locator': {
+                    'by': 'ID', 'locator': 'click-menu'
+                },
+                'links': [
+                    {
+                        'name': 'home',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="index.html"]'
+                        },
+                        'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+                    },
+                    {
+                        'name': 'form',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="form.html"]'
+                        },
+                        'target': {'path': 'form.html', 'relative_to': 'BASE_URL'}
+                    },
+                    {
+                        'name': 'modal',
+                        'link_locator': {
+                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="modal.html"]'
+                        },
+                        'target': {'path': 'modal.html', 'relative_to': 'BASE_URL'}
+                    },
+                ]
+            }
+        },
+    ]
+    # (Default: False) Whether or not the navbar is collapsible
+    COLLAPSIBLE = True
     # REQUIRED: Locator for the collapsible menu element
-    MENU_LOCATOR = None
+    MENU_LOCATOR = (By.ID, 'nav-menu')
     # REQUIRED: Locator for the button that expands the nav menu
-    EXPAND_BUTTON_LOCATOR = None
+    EXPAND_BUTTON_LOCATOR = (By.ID, 'navbar-toggle')
     # (Optional) Locator for the button that collapses the nav menu.
     # If not set, the value from EXPAND_BUTTON_LOCATOR will be used
     COLLAPSE_BUTTON_LOCATOR = None
@@ -150,5 +203,5 @@ class NoYAMLCollapsibleNavObject(prototypes.NavObject):
     # (Default = True) True if element is a fixed navbar, False otherwise. If
     # set to False, click_page_link() and hover_over_page_link() will scroll
     # the target link into view before interacting with it
-    # FIXED = True
+    FIXED = False
 

--- a/test/page-object-tests/page_object_tests/pages/yaml_collapsible_nav.yml
+++ b/test/page-object-tests/page_object_tests/pages/yaml_collapsible_nav.yml
@@ -1,0 +1,72 @@
+# NavObject YAML Documentation: 
+# https://connordelacruz.com/webdriver-test-tools/yaml.html#navobjects
+
+# REPLACE <PLACEHOLDER VALUES> BELOW AND ADD ITEMS TO THE links LIST:
+
+
+nav:
+  # (Default: true) Whether the navbar is fixed to the window.
+  # Uncomment to override
+  fixed: false
+  # (Default: false)
+  collapsible: true
+  # REQUIRED: Locator for the collapsible menu element
+  menu_locator:
+    by: ID
+    locator: nav-menu
+  # REQUIRED: Locator for the button that collapses the nav menu
+  expand_button_locator:
+    by: ID
+    locator: navbar-toggle
+  # (Optional) Locator for the button that collapses the nav menu.
+  # Uncomment if expand and collapse buttons have different locators
+  # collapse_button_locator:
+  #   by: <BY>
+  #   locator: <LOCATOR>
+  # List of links in the navbar
+  links:
+    - name: home
+      link_locator:
+        by: CLASS_NAME
+        locator: navbar-brand
+      target:
+        path: index.html
+        relative_to: BASE_URL
+    - name: section3
+      link_locator:
+        by: CSS_SELECTOR
+        locator: 'a[href="#section3"]'
+      click: section
+      target: '#section3'
+    - name: click-menu
+      link_locator:
+        by: ID
+        locator: click-menu-link
+      click: menu
+      menu:
+        menu_locator:
+          by: ID
+          locator: click-menu
+        links:
+          - name: home
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="index.html"]'
+            target:
+              path: index.html
+              relative_to: BASE_URL
+          - name: form
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="form.html"]'
+            target:
+              path: form.html
+              relative_to: BASE_URL
+          - name: modal
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="modal.html"]'
+            target:
+              path: modal.html
+              relative_to: BASE_URL
+

--- a/test/page-object-tests/page_object_tests/pages/yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/yaml_nav.py
@@ -28,6 +28,8 @@ class YAMLNavObject(prototypes.NavObject):
 
 class YAMLCollapsibleNavObject(prototypes.NavObject):
 
+    PAGE_FILENAME = 'collapsible_navbar.html'
+
     class Locator:
         """WebDriver locator tuples for any elements that will need to be
         accessed by this page object.

--- a/test/page-object-tests/page_object_tests/pages/yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/yaml_nav.py
@@ -1,0 +1,28 @@
+import os
+
+from selenium.webdriver.common.by import By
+from webdriver_test_tools.pageobject import *
+from webdriver_test_tools.webdriver import actions, locate
+
+from page_object_tests.config import SiteConfig
+
+
+class YAMLNavObject(prototypes.NavObject):
+
+    PAGE_FILENAME = 'navbar.html'
+
+    class Locator:
+        """WebDriver locator tuples for any elements that will need to be
+        accessed by this page object.
+        """
+        pass
+
+    # SET THE FOLLOWING ATTRIBUTES TO USE IN NavObject METHODS
+
+    # Path to YAML file representing the object
+    YAML_FILE = os.path.join(os.path.dirname(__file__), 'yaml_nav.yml')
+
+    # Used for internal methods (do not modify)
+    SITE_CONFIG = SiteConfig
+
+

--- a/test/page-object-tests/page_object_tests/pages/yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/yaml_nav.py
@@ -26,3 +26,18 @@ class YAMLNavObject(prototypes.NavObject):
     SITE_CONFIG = SiteConfig
 
 
+class YAMLCollapsibleNavObject(prototypes.NavObject):
+
+    class Locator:
+        """WebDriver locator tuples for any elements that will need to be
+        accessed by this page object.
+        """
+        pass
+
+    # Path to YAML file representing the object
+    YAML_FILE = os.path.join(os.path.dirname(__file__), 'yaml_collapsible_nav.yml')
+
+    # Used for internal methods (do not modify)
+    SITE_CONFIG = SiteConfig
+
+

--- a/test/page-object-tests/page_object_tests/pages/yaml_nav.yml
+++ b/test/page-object-tests/page_object_tests/pages/yaml_nav.yml
@@ -1,0 +1,81 @@
+
+nav:
+  fixed: false
+  links:
+    - name: home
+      link_locator:
+        by: CLASS_NAME
+        locator: navbar-brand
+      target:
+        path: index.html
+        relative_to: BASE_URL
+    - name: section3
+      link_locator:
+        by: CSS_SELECTOR
+        locator: 'a[href="#section3"]'
+      click: section
+      target: '#section3'
+    - name: hover-menu
+      link_locator:
+        by: ID
+        locator: hover-menu-link
+      click: none
+      hover: menu
+      menu:
+        menu_locator:
+          by: ID
+          locator: hover-menu
+        links:
+          - name: home
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#hover-menu a[href="index.html"]'
+            target:
+              path: index.html
+              relative_to: BASE_URL
+          - name: form
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#hover-menu a[href="form.html"]'
+            target:
+              path: form.html
+              relative_to: BASE_URL
+          - name: modal
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#hover-menu a[href="modal.html"]'
+            target:
+              path: modal.html
+              relative_to: BASE_URL
+    - name: click-menu
+      link_locator:
+        by: ID
+        locator: click-menu-link
+      click: menu
+      menu:
+        menu_locator:
+          by: ID
+          locator: click-menu
+        links:
+          - name: home
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="index.html"]'
+            target:
+              path: index.html
+              relative_to: BASE_URL
+          - name: form
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="form.html"]'
+            target:
+              path: form.html
+              relative_to: BASE_URL
+          - name: modal
+            link_locator:
+              by: CSS_SELECTOR
+              locator: '#click-menu a[href="modal.html"]'
+            target:
+              path: modal.html
+              relative_to: BASE_URL
+

--- a/test/page-object-tests/page_object_tests/tests/nav.py
+++ b/test/page-object-tests/page_object_tests/tests/nav.py
@@ -1,0 +1,42 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+import webdriver_test_tools
+from webdriver_test_tools.testcase import *
+
+from page_object_tests import config
+from page_object_tests.pages.yaml_nav import YAMLNavObject
+
+
+class NavObjectTestCase(WebDriverTestCase):
+    """Test NavObject prototype"""
+
+    # URL to go to at the start of each test
+    SITE_URL = config.SiteConfig.SITE_URL + YAMLNavObject.PAGE_FILENAME
+
+    # Test Methods
+    # TODO: fixed navs, collapsible navs
+
+    def test_nav_object_yaml(self):
+        """Test links for pages and sections, hover and click dropdowns (YAML)"""
+        nav_object = YAMLNavObject(self.driver)
+        self._test_nav_object(nav_object)
+
+    def _test_nav_object(self, nav_object):
+        with self.subTest('Test page link'):
+            home_url = nav_object.click_link('home')
+            self.assertUrlChange(home_url)
+            self.driver.get(self.SITE_URL)
+        with self.subTest('Test section link'):
+            section_id = nav_object.click_link('section3')
+            self.assertInView((By.CSS_SELECTOR, section_id))
+        with self.subTest('Test hover menu'):
+            menu_object = nav_object.hover_over_link('hover-menu')
+            # Test is_visible() method and assert that element is visible for consistency
+            self.assertTrue(menu_object.is_visible(), msg='is_visible() returned False')
+            self.assertVisible(menu_object.locator, msg='Element located with menu_object.locator is invisible')
+        with self.subTest('Test click menu'):
+            menu_object = nav_object.click_link('click-menu')
+            # Test is_visible() method and assert that element is visible for consistency
+            self.assertTrue(menu_object.is_visible(), msg='is_visible() returned False')
+            self.assertVisible(menu_object.locator, msg='Element located with menu_object.locator is invisible')
+

--- a/test/page-object-tests/page_object_tests/tests/nav.py
+++ b/test/page-object-tests/page_object_tests/tests/nav.py
@@ -15,7 +15,7 @@ class NavObjectTestCase(WebDriverTestCase):
     SITE_URL = config.SiteConfig.SITE_URL + YAMLNavObject.PAGE_FILENAME
 
     # Test Methods
-    # TODO: fixed navs, collapsible navs
+    # TODO: fixed navs
 
     def test_nav_object_yaml(self):
         """(Non-collapsible) Test links for pages and sections, hover and click dropdowns (YAML)"""
@@ -53,11 +53,16 @@ class CollapsibleNavObjectTestCase(WebDriverTestCase):
     SITE_URL = config.SiteConfig.SITE_URL + YAMLCollapsibleNavObject.PAGE_FILENAME
 
     # Test Methods
-    # TODO: fixed navs, collapsible navs
+    # TODO: fixed navs
 
     def test_nav_object_yaml(self):
         """(Collapsible) Test links for pages and sections and click dropdowns (YAML)"""
         nav_object = YAMLCollapsibleNavObject(self.driver)
+        self._test_nav_object(nav_object)
+
+    def test_nav_object_no_yaml(self):
+        """(Collapsible) Test links for pages and sections and click dropdowns (no YAML)"""
+        nav_object = NoYAMLCollapsibleNavObject(self.driver)
         self._test_nav_object(nav_object)
 
     def _test_nav_object(self, nav_object):

--- a/test/page-object-tests/page_object_tests/tests/nav.py
+++ b/test/page-object-tests/page_object_tests/tests/nav.py
@@ -5,6 +5,7 @@ from webdriver_test_tools.testcase import *
 
 from page_object_tests import config
 from page_object_tests.pages.yaml_nav import YAMLNavObject, YAMLCollapsibleNavObject
+from page_object_tests.pages.no_yaml_nav import NoYAMLNavObject, NoYAMLCollapsibleNavObject
 
 
 class NavObjectTestCase(WebDriverTestCase):
@@ -19,6 +20,11 @@ class NavObjectTestCase(WebDriverTestCase):
     def test_nav_object_yaml(self):
         """(Non-collapsible) Test links for pages and sections, hover and click dropdowns (YAML)"""
         nav_object = YAMLNavObject(self.driver)
+        self._test_nav_object(nav_object)
+
+    def test_nav_object_no_yaml(self):
+        """(Non-collapsible) Test links for pages and sections, hover and click dropdowns (no YAML)"""
+        nav_object = NoYAMLNavObject(self.driver)
         self._test_nav_object(nav_object)
 
     def _test_nav_object(self, nav_object):

--- a/test/page-object-tests/page_object_tests/tests/nav.py
+++ b/test/page-object-tests/page_object_tests/tests/nav.py
@@ -4,11 +4,11 @@ import webdriver_test_tools
 from webdriver_test_tools.testcase import *
 
 from page_object_tests import config
-from page_object_tests.pages.yaml_nav import YAMLNavObject
+from page_object_tests.pages.yaml_nav import YAMLNavObject, YAMLCollapsibleNavObject
 
 
 class NavObjectTestCase(WebDriverTestCase):
-    """Test NavObject prototype"""
+    """Test NavObject prototype (COLLAPSIBLE = False)"""
 
     # URL to go to at the start of each test
     SITE_URL = config.SiteConfig.SITE_URL + YAMLNavObject.PAGE_FILENAME
@@ -17,7 +17,7 @@ class NavObjectTestCase(WebDriverTestCase):
     # TODO: fixed navs, collapsible navs
 
     def test_nav_object_yaml(self):
-        """Test links for pages and sections, hover and click dropdowns (YAML)"""
+        """(Non-collapsible) Test links for pages and sections, hover and click dropdowns (YAML)"""
         nav_object = YAMLNavObject(self.driver)
         self._test_nav_object(nav_object)
 
@@ -35,6 +35,50 @@ class NavObjectTestCase(WebDriverTestCase):
             self.assertTrue(menu_object.is_visible(), msg='is_visible() returned False')
             self.assertVisible(menu_object.locator, msg='Element located with menu_object.locator is invisible')
         with self.subTest('Test click menu'):
+            menu_object = nav_object.click_link('click-menu')
+            # Test is_visible() method and assert that element is visible for consistency
+            self.assertTrue(menu_object.is_visible(), msg='is_visible() returned False')
+            self.assertVisible(menu_object.locator, msg='Element located with menu_object.locator is invisible')
+
+class CollapsibleNavObjectTestCase(WebDriverTestCase):
+    """Test NavObject prototype (COLLAPSIBLE = True)"""
+
+    # URL to go to at the start of each test
+    SITE_URL = config.SiteConfig.SITE_URL + YAMLCollapsibleNavObject.PAGE_FILENAME
+
+    # Test Methods
+    # TODO: fixed navs, collapsible navs
+
+    def test_nav_object_yaml(self):
+        """(Collapsible) Test links for pages and sections and click dropdowns (YAML)"""
+        nav_object = YAMLCollapsibleNavObject(self.driver)
+        self._test_nav_object(nav_object)
+
+    def _test_nav_object(self, nav_object):
+        with self.subTest('Expand nav menu'):
+            nav_object.click_expand_button()
+            # Test is_expanded() method and assert that element is visible for consistency
+            # TODO: animation causes false positive, so is_expanded() not properly tested
+            # self.assertTrue(nav_object.is_expanded(), msg='is_expanded() returned False')
+            self.assertVisible(nav_object.MENU_LOCATOR, msg='Element located with nav_object.MENU_LOCATOR is invisible')
+        with self.subTest('Collapse nav menu'):
+            nav_object.click_collapse_button()
+            # Test is_expanded() method and assert that element is not visible for consistency
+            # TODO: animation causes false positive, so is_expanded() not properly tested
+            # self.assertFalse(nav_object.is_expanded(), msg='is_expanded() returned True')
+            self.assertInvisible(nav_object.MENU_LOCATOR, msg='Element located with nav_object.MENU_LOCATOR is visible')
+        with self.subTest('Test page link'):
+            home_url = nav_object.click_link('home')
+            self.assertUrlChange(home_url)
+            self.driver.get(self.SITE_URL)
+        with self.subTest('Test section link'):
+            if not nav_object.is_expanded():
+                nav_object.click_expand_button()
+            section_id = nav_object.click_link('section3')
+            self.assertInView((By.CSS_SELECTOR, section_id))
+        with self.subTest('Test click menu'):
+            if not nav_object.is_expanded():
+                nav_object.click_expand_button()
             menu_object = nav_object.click_link('click-menu')
             # Test is_visible() method and assert that element is visible for consistency
             self.assertTrue(menu_object.is_visible(), msg='is_visible() returned False')

--- a/webdriver_test_tools/__about__.py
+++ b/webdriver_test_tools/__about__.py
@@ -10,6 +10,7 @@ __title__ = 'webdriver_test_tools'
 __project__ = 'WebDriver Test Tools'
 __summary__ = 'A front-end testing framework using Selenium WebDriver and Python'
 
+# TODO: 2.9.0
 __release__ = '2.8.1-alpha'
 __version__ = __release__.split('-')[0]
 __devstatus__ = 'Development Status :: 3 - Alpha'

--- a/webdriver_test_tools/config/site.py
+++ b/webdriver_test_tools/config/site.py
@@ -10,3 +10,37 @@ class SiteConfig:
     SITE_URL = ''
     BASE_URL = ''
 
+    @classmethod
+    def parse_relative_url_dict(cls, url_dict):
+        """Takes a URL dictionary and returns a full URL based on the values.
+        Used to parse :ref:`YAML URL dictionaries <yaml-relative-urls>`
+
+        :param url_dict: A dictionary with the following keys:
+
+            * 'path': The path to a page, relative ot the ``SiteConfig``
+              attribute specified in 'relative_to'
+            * 'relative_to': A valid attribute in the ``SiteConfig`` class to
+              use as a base URL. If the value of that attribute does not have a
+              trailing '/', one will be added before appending the value of
+              'path'
+
+        :return: A full URL based on the values of the URL dictionary
+
+        :raises ValueError: if ``url_dict['relative_to']`` is not a valid
+            attribute name in this class
+        :raises KeyError: if 'path' or 'relative_to' are not keys in
+            ``url_dict``
+        """
+        relative_to = url_dict['relative_to']
+        try:
+            base_url = getattr(cls, relative_to)
+        except AttributeError as e:
+            error_msg = "Invalid URL 'relative_to' value (relative_to: {}). ".format(relative_to)
+            error_msg += 'Must be a valid attribute declared in SiteConfig class'
+            raise ValueError(error_msg)
+        # Append a '/' if not present
+        if not base_url.endswith('/'):
+            base_url += '/'
+        return base_url + url_dict['path']
+
+

--- a/webdriver_test_tools/pageobject/form.py
+++ b/webdriver_test_tools/pageobject/form.py
@@ -58,14 +58,15 @@ class InputObject(BasePage):
 
 
     def __init__(self, driver, input_dict):
-        """Initialize ``InputObject`` using parsed YAML
+        """Initialize ``InputObject`` using parsed YAML or input dictionary
 
-        See :ref:`YAML inputs doc <yaml-inputs>` for details on ``input_dict``
-        syntax.
+        See :ref:`YAML inputs documentation <yaml-inputs>` for details on
+        ``input_dict`` syntax.
 
         :param driver: Selenium WebDriver object
-        :param input_dict: Parsed dictionary from YAML file inputs list. Must
-            have 'name' key set
+        :param input_dict: Input dictionary using syntax specified in
+            :ref:`YAML inputs documentation <yaml-inputs>`. Must have 'name'
+            key set
         """
         super().__init__(driver)
         # 'name' is required, so assume that it's a valid key and raise errors
@@ -361,7 +362,8 @@ class FormObject(YAMLParsingPageObject):
 
     :var FormObject.inputs: A dictionary mapping input names to the
         corresponding :class:`InputObject` instances. The keys correspond with
-        the ``name`` keys in the YAML representation of the form
+        the ``name`` keys in the YAML representation of the form (or the 'name'
+        keys in :attr:`INPUT_DICTS` if :attr:`YAML_FILE` is ``None``)
 
     If :attr:`YAML_FILE` is ``None``, subclasses must set the following
     attribute:
@@ -369,7 +371,7 @@ class FormObject(YAMLParsingPageObject):
     :var FormObject.INPUT_DICTS: List of input dictionaries. These are used to
         initialize the :class:`InputObject` instances in :attr:`inputs` at
         runtime. These dictionaries use the same syntax as :ref:`YAML inputs
-        <yaml-inputs>`.
+        <yaml-inputs>`
     """
 
     _YAML_ROOT_KEY = 'form'

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -8,10 +8,10 @@ from webdriver_test_tools.webdriver import actions
 # Link Page Objects
 
 class NavLinkObject(BasePage):
-    # TODO: doc and implement
+    """Page object prototype for nav links"""
 
     class ActionTypes:
-        # TODO: doc
+        """Link click/hover action types"""
         PAGE = 'page'
         SECTION = 'section'
         MENU = 'menu'
@@ -22,6 +22,10 @@ class NavLinkObject(BasePage):
         HOVER_ACTIONS = [
             MENU
         ]
+        # Required attributes for types
+        REQUIRES_TARGET = [
+            PAGE, SECTION
+        ]
 
     def __init__(self, driver, link_dict):
         # TODO: doc
@@ -30,15 +34,15 @@ class NavLinkObject(BasePage):
         # and raise errors otherwise
         self.name = link_dict['name']
         self.locator = utils.yaml.to_locator(link_dict['link_locator'])
-        # TODO: raise value errors if invalid
+        # TODO: raise value errors if invalid (allow either to be None though)
         self.click_action = link_dict.get('click', self.ActionTypes.PAGE)
         self.hover_action = link_dict.get('hover', None)
-        # TODO: raise key error if click_action is page/section
-        self.target = link_dict.get('target', None)
+        # Get target attribute if required
+        if self.click_action in self.ActionTypes.REQUIRES_TARGET:
+            self.target = link_dict['target']
         # Parse menu if applicable
         if self.ActionTypes.MENU in [self.click_action, self.hover_action]:
-            # TODO: self.menu = NavMenuObject(self.driver, link_dict['menu'])
-            pass
+            self.menu = NavMenuObject(self.driver, link_dict['menu'])
 
     # WebElement retrieval
 
@@ -54,21 +58,32 @@ class NavLinkObject(BasePage):
     # Actions
 
     def click_link(self):
+        """Click the link
+
+        :return: Link target (url or section ID) if ``self.click_action`` is
+            'page' or 'section', or a :class:`NavMenuObject` instance if
+            ``self.click_action`` is 'menu'
+        """
         actions.scroll.to_and_click(self.driver, self.find_link_element(), False)
-        # TODO: return something? (and doc)
+        return self.menu if self.click_action == self.ActionTypes.MENU else self.target
 
     def hover_over_link(self):
+        """Hover over the link element
+
+        :return: :class:`NavMenuObject` instance (or ``None`` if no hover
+            action is defined)
+        """
         link_element = self.find_link_element()
         actions.scroll.into_view(self.driver, link_element, False)
         action_chain = ActionChains(self.driver)
         action_chain.move_to_element(link_element).perform()
-        # TODO: return menu object? (and doc)
+        return self.menu if self.hover_action == self.ActionTypes.MENU else None
 
 
 # Menu Page Objects
 
 class NavMenuObject(BasePage):
-    # TODO: doc and implement
+    """Page object prototype for dropdown/collapsible nav menus"""
 
     def __init__(self, driver, menu_dict):
         # TODO: doc
@@ -98,12 +113,30 @@ class NavMenuObject(BasePage):
     # Actions
 
     def click_link(self, link_name):
-        # TODO: doc, return something, errors?
-        self.links[link_name].click_link()
+        """Click a link in the menu
+
+        :param link_name: Name of the link (specified in YAML or link
+            dictionary) i.e. a valid key in ``self.links``
+
+        :return: The returned value of clicking the link. See
+            :meth:`NavLinkObject.click_link` for possible values
+        """
+        # TODO: KeyError message?
+        return self.links[link_name].click_link()
 
     def hover_over_link(self, link_name):
-        # TODO: doc, return something, errors?
-        self.links[link_name].hover_over_link()
+        """Hover over a link in the menu
+
+        :param link_name: Name of the link (specified in YAML or link
+            dictionary) i.e. a valid key in ``self.links``
+
+        :return: The returned value of hovering over the link. See
+            :meth:`NavLinkObject.hover_over_link` for possible values
+        """
+        # TODO: KeyError message?
+        return self.links[link_name].hover_over_link()
+
+    # TODO: is_visible()
 
 
 # Navbar Page Objects
@@ -124,6 +157,7 @@ class NavObject(BasePage):
         scroll the target link into view before interacting with it
     """
 
+    # TODO: deprecate workflow
     # Link maps
     LINK_MAP = {}
     HOVER_MAP = {}

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -29,7 +29,7 @@ class NavLinkObject(BasePage):
         ]
 
     def __init__(self, driver, link_dict, site_config):
-        # TODO: doc
+        # TODO: doc, link to YAML
         super().__init__(driver)
         # 'name' and 'link_locator' required, so assume that they're valid keys
         # and raise errors otherwise
@@ -49,9 +49,8 @@ class NavLinkObject(BasePage):
             target = link_dict['target']
             # TODO: if section type and target doesn't start w/ #, add one?
             if isinstance(target, dict):
-                # TODO: extract to method, error handling, figure out if this is the best way to handle this
-                base_url = getattr(site_config, target['relative_to'])
-                target = base_url + target['path']
+                # TODO: exceptions?
+                target = site_config.parse_relative_url_dict(target)
             self.target = target
         # Parse menu if applicable
         if self.ActionTypes.MENU in [self.click_action, self.hover_action]:

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -73,7 +73,7 @@ class NavLinkObject(BasePage):
         if self.click_action in self.ActionTypes.REQUIRES_TARGET:
             target = link_dict['target']
             # Add '#' to the front of section targets if not present
-            if self.click_action == self.ActionTypes.SECTION and not self.target.startswith('#'):
+            if self.click_action == self.ActionTypes.SECTION and not target.startswith('#'):
                 target = '#' + target
             if isinstance(target, dict):
                 target = site_config.parse_relative_url_dict(target)

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -265,6 +265,11 @@ class NavObject(YAMLParsingPageObject):
         runtime. These dictionaries use the same syntax as :ref:`YAML links
         <yaml-links>`
 
+        .. todo::
+
+            ``LINK_DICTS`` syntax is kind of cluttered, will likely re-work to
+            be cleaner in future versions
+
     ---
 
     The following attributes are deprecated as of version 2.9.0, and will be

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -68,7 +68,9 @@ class NavLinkObject(BasePage):
         # Get target attribute if required
         if self.click_action in self.ActionTypes.REQUIRES_TARGET:
             target = link_dict['target']
-            # TODO: if section type and target doesn't start w/ #, add one?
+            # Add '#' to the front of section targets if not present
+            if self.click_action == self.ActionTypes.SECTION and not self.target.startswith('#'):
+                target = '#' + target
             if isinstance(target, dict):
                 # TODO: exceptions?
                 target = site_config.parse_relative_url_dict(target)
@@ -93,10 +95,12 @@ class NavLinkObject(BasePage):
     def click_link(self):
         """Click the link
 
-        :return: Link target (url or section ID) if ``self.click_action`` is
-            'page' or 'section', or a :class:`NavMenuObject` instance if
-            ``self.click_action`` is 'menu' (or ``None`` if
-            ``self.click_action`` is ``None``)
+        :return: Return value depends on ``self.click_action``:
+
+            * 'page': Returns the URL to the link target
+            * 'section': Returns the target section ID (prefixed with '#')
+            * 'menu': Returns a :class:`NavMenuObject` instance
+            * None: Returns ``None``
         """
         actions.scroll.to_and_click(self.driver, self.find_link_element(), False)
         return self.menu if self.click_action == self.ActionTypes.MENU else self.target
@@ -167,8 +171,9 @@ class NavMenuObject(BasePage):
 
         :return: The returned value of clicking the link. See
             :meth:`NavLinkObject.click_link` for possible values
+
+        :raises KeyError: If ``link_name`` is not a valid key in ``self.links``
         """
-        # TODO: KeyError message?
         return self.links[link_name].click_link()
 
     def hover_over_link(self, link_name):
@@ -179,8 +184,9 @@ class NavMenuObject(BasePage):
 
         :return: The returned value of hovering over the link. See
             :meth:`NavLinkObject.hover_over_link` for possible values
+
+        :raises KeyError: If ``link_name`` is not a valid key in ``self.links``
         """
-        # TODO: KeyError message?
         return self.links[link_name].hover_over_link()
 
     def is_visible(self):
@@ -329,7 +335,6 @@ class NavObject(YAMLParsingPageObject):
                 self.COLLAPSE_BUTTON_LOCATOR = self.EXPAND_BUTTON_LOCATOR
         self._initialize_links(self.LINK_DICTS, from_yaml=False)
 
-    # TODO: overlaps w/ menu, merge?
     def _initialize_links(self, link_dicts, from_yaml=True):
         """Initialize :class:`NavLinkObject` instances in ``self.links``
 
@@ -368,6 +373,8 @@ class NavObject(YAMLParsingPageObject):
 
         :return: The returned value of clicking the link. See
             :meth:`NavLinkObject.click_link` for possible values
+
+        :raises KeyError: If ``link_name`` is not a valid key in ``self.links``
         """
         return self.links[link_name].click_link()
 
@@ -379,6 +386,8 @@ class NavObject(YAMLParsingPageObject):
 
         :return: The returned value of hovering over the link. See
             :meth:`NavLinkObject.hover_over_link` for possible values
+
+        :raises KeyError: If ``link_name`` is not a valid key in ``self.links``
         """
         return self.links[link_name].hover_over_link()
 

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -51,8 +51,8 @@ class NavLinkObject(BasePage):
         self.locator = utils.yaml.to_locator(link_dict['link_locator'])
         self.click_action = link_dict.get('click', self.ActionTypes.PAGE)
         if self.click_action not in self.ActionTypes.CLICK_ACTIONS:
-            # TODO: appropriate msg
-            error_msg = ''
+            error_msg = "Invalid value 'click' action for link (link: {}). ".format(str(link_dict))
+            error_msg += 'Valid click actions: {}'.format(str(self.ActionTypes.CLICK_ACTIONS))
             raise ValueError(error_msg)
         if self.click_action == self.ActionTypes.NONE:
             self.click_action = None
@@ -60,8 +60,8 @@ class NavLinkObject(BasePage):
             self.target = None
         self.hover_action = link_dict.get('hover', None)
         if self.hover_action and self.hover_action not in self.ActionTypes.HOVER_ACTIONS:
-            # TODO: appropriate msg
-            error_msg = ''
+            error_msg = "Invalid value 'hover' action for link (link: {}). ".format(str(link_dict))
+            error_msg += 'Valid hover actions: {}'.format(str(self.ActionTypes.HOVER_ACTIONS))
             raise ValueError(error_msg)
         if self.hover_action == self.ActionTypes.NONE:
             self.hover_action = None
@@ -141,7 +141,7 @@ class NavMenuObject(BasePage):
         self.locator = utils.yaml.to_locator(menu_dict['menu_locator'])
         self.links = {}
         for link_dict in menu_dict['links']:
-            # TODO: except key error? (or let it get handled by calling object)
+            # TODO: except key error, update message to show menu
             link_name = link_dict['name']
             # TODO: raise value error if name not unique (specify that this is a menu)
             self.links[link_name] = NavLinkObject(self.driver, link_dict, site_config)

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -39,12 +39,15 @@ class NavLinkObject(BasePage):
         self.click_action = link_dict.get('click', self.ActionTypes.PAGE)
         if self.click_action == self.ActionTypes.NONE:
             self.click_action = None
+            # Click target should also be None
+            self.target = None
         self.hover_action = link_dict.get('hover', None)
         if self.hover_action == self.ActionTypes.NONE:
             self.hover_action = None
         # Get target attribute if required
         if self.click_action in self.ActionTypes.REQUIRES_TARGET:
             target = link_dict['target']
+            # TODO: if section type and target doesn't start w/ #, add one?
             if isinstance(target, dict):
                 # TODO: extract to method, error handling, figure out if this is the best way to handle this
                 base_url = getattr(site_config, target['relative_to'])
@@ -72,7 +75,8 @@ class NavLinkObject(BasePage):
 
         :return: Link target (url or section ID) if ``self.click_action`` is
             'page' or 'section', or a :class:`NavMenuObject` instance if
-            ``self.click_action`` is 'menu'
+            ``self.click_action`` is 'menu' (or ``None`` if
+            ``self.click_action`` is ``None``)
         """
         actions.scroll.to_and_click(self.driver, self.find_link_element(), False)
         return self.menu if self.click_action == self.ActionTypes.MENU else self.target

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -324,6 +324,9 @@ class NavObject(YAMLParsingPageObject):
 
     def no_yaml_init(self):
         """Initialize ``self.links`` using values in :attr:`LINK_DICTS`"""
+        if self.COLLAPSIBLE:
+            if not self.COLLAPSE_BUTTON_LOCATOR:
+                self.COLLAPSE_BUTTON_LOCATOR = self.EXPAND_BUTTON_LOCATOR
         self._initialize_links(self.LINK_DICTS, from_yaml=False)
 
     # TODO: overlaps w/ menu, merge?

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -1,10 +1,114 @@
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver import ActionChains
 
-from webdriver_test_tools.pageobject import BasePage
+from webdriver_test_tools.pageobject import utils, BasePage, YAMLParsingPageObject
 from webdriver_test_tools.webdriver import actions
 
 
+# Link Page Objects
+
+class NavLinkObject(BasePage):
+    # TODO: doc and implement
+
+    class ActionTypes:
+        # TODO: doc
+        PAGE = 'page'
+        SECTION = 'section'
+        MENU = 'menu'
+        # Click/hover support for each type
+        CLICK_ACTIONS = [
+            PAGE, SECTION, MENU
+        ]
+        HOVER_ACTIONS = [
+            MENU
+        ]
+
+    def __init__(self, driver, link_dict):
+        # TODO: doc
+        super().__init__(driver)
+        # 'name' and 'link_locator' required, so assume that they're valid keys
+        # and raise errors otherwise
+        self.name = link_dict['name']
+        self.locator = utils.yaml.to_locator(link_dict['link_locator'])
+        # TODO: raise value errors if invalid
+        self.click_action = link_dict.get('click', self.ActionTypes.PAGE)
+        self.hover_action = link_dict.get('hover', None)
+        # TODO: raise key error if click_action is page/section
+        self.target = link_dict.get('target', None)
+        # Parse menu if applicable
+        if self.ActionTypes.MENU in [self.click_action, self.hover_action]:
+            # TODO: self.menu = NavMenuObject(self.driver, link_dict['menu'])
+            pass
+
+    # WebElement retrieval
+
+    def find_link_element(self):
+        """Returns the ``WebElement`` object located by ``self.locator``
+
+        Shorthand for ``self.find_element(self.locator)``
+
+        :return: ``WebElement`` object for the link
+        """
+        return self.find_element(self.locator)
+
+    # Actions
+
+    def click_link(self):
+        actions.scroll.to_and_click(self.driver, self.find_link_element(), False)
+        # TODO: return something? (and doc)
+
+    def hover_over_link(self):
+        link_element = self.find_link_element()
+        actions.scroll.into_view(self.driver, link_element, False)
+        action_chain = ActionChains(self.driver)
+        action_chain.move_to_element(link_element).perform()
+        # TODO: return menu object? (and doc)
+
+
+# Menu Page Objects
+
+class NavMenuObject(BasePage):
+    # TODO: doc and implement
+
+    def __init__(self, driver, menu_dict):
+        # TODO: doc
+        super().__init__(driver)
+        # 'menu_locator' is required, so assume it's a valid key and raise
+        # errors otherwise
+        self.locator = menu_dict['menu_locator']
+        # TODO: link map
+        self.links = {}
+        for link_dict in menu_dict['links']:
+            # TODO: except key error
+            link_name = link_dict['name']
+            # TODO: raise (yaml) value error if name not unique
+            self.links[link_name] = NavLinkObject(self.driver, link_dict)
+
+    # WebElement retrieval
+
+    def find_menu_element(self):
+        """Returns the ``WebElement`` object located by ``self.locator``
+
+        Shorthand for ``self.find_element(self.locator)``
+
+        :return: ``WebElement`` object for the menu
+        """
+        return self.find_element(self.locator)
+
+    # Actions
+
+    def click_link(self, link_name):
+        # TODO: doc, return something, errors?
+        self.links[link_name].click_link()
+
+    def hover_over_link(self, link_name):
+        # TODO: doc, return something, errors?
+        self.links[link_name].hover_over_link()
+
+
+# Navbar Page Objects
+
+# TODO: YAML support, implement new objects, update docs
 class NavObject(BasePage):
     """Page object prototype for navbars
 

--- a/webdriver_test_tools/pageobject/prototypes.py
+++ b/webdriver_test_tools/pageobject/prototypes.py
@@ -1,7 +1,7 @@
 """Subclasses of BasePage with additional functions for convenience.
 
-These classes define common operations and attributes for various common components.
-These can be subclassed in test projects if useful.
+These classes define common operations and attributes for various common
+components.  These can be subclassed in test projects if useful.
 
 This module imports the following classes:
 
@@ -10,9 +10,13 @@ This module imports the following classes:
     :class:`webdriver_test_tools.pageobject.modal.ModalObject`
     :class:`webdriver_test_tools.pageobject.nav.NavLinkObject`
     :class:`webdriver_test_tools.pageobject.nav.NavMenuObject`
-    :class:`webdriver_test_tools.pageobject.nav.CollapsibleNavObject`
     :class:`webdriver_test_tools.pageobject.nav.NavObject`
     :class:`webdriver_test_tools.pageobject.webpage.WebPageObject`
+
+The following deprecated classes are also imported, but may be removed in
+future versions:
+
+    :class:`webdriver_test_tools.pageobject.nav.CollapsibleNavObject`
 """
 
 from .webpage import WebPageObject

--- a/webdriver_test_tools/pageobject/prototypes.py
+++ b/webdriver_test_tools/pageobject/prototypes.py
@@ -8,13 +8,17 @@ This module imports the following classes:
     :class:`webdriver_test_tools.pageobject.form.FormObject`
     :class:`webdriver_test_tools.pageobject.form.InputObject`
     :class:`webdriver_test_tools.pageobject.modal.ModalObject`
+    :class:`webdriver_test_tools.pageobject.nav.NavLinkObject`
+    :class:`webdriver_test_tools.pageobject.nav.NavMenuObject`
     :class:`webdriver_test_tools.pageobject.nav.CollapsibleNavObject`
     :class:`webdriver_test_tools.pageobject.nav.NavObject`
     :class:`webdriver_test_tools.pageobject.webpage.WebPageObject`
 """
 
 from .webpage import WebPageObject
-from .nav import NavObject, CollapsibleNavObject
+from .nav import (
+    NavLinkObject, NavMenuObject, NavObject, CollapsibleNavObject
+)
 from .form import FormObject, InputObject
 from .modal import ModalObject
 

--- a/webdriver_test_tools/pageobject/webpage.py
+++ b/webdriver_test_tools/pageobject/webpage.py
@@ -75,36 +75,23 @@ class WebPageObject(YAMLParsingPageObject):
             URL
 
         :raises YAMLKeyError: if ``url`` is missing either required key
+        :raises YAMLValueError: if ``url['relative_to']`` is not a valid
+            attribute name of :attr:`SITE_CONFIG` class
         """
         # TODO: what if URL is an exact attribute in site config and not relative?
         try:
             return (
                 url['path'],
-                self._get_base_url(url['relative_to']) + url['path']
+                self.SITE_CONFIG.parse_relative_url_dict(url)
             )
         except KeyError as e:
             raise utils.yaml.YAMLKeyError(
                 "Missing required {} key in web page 'url' dictionary"
             )
-
-    def _get_base_url(self, relative_to):
-        """Helper method for resolving url relative_to key
-
-        :param relative_to: Name of an attribute in :attr:`SITE_CONFIG` class
-
-        :return: The value of the specified attribute in :attr:`SITE_CONFIG`
-            class
-
-        :raises YAMLValueError: if ``relative_to`` is not a valid attribute
-            name of :attr:`SITE_CONFIG`
-        """
-        try:
-            base_url = getattr(self.SITE_CONFIG, relative_to)
-        except AttributeError as e:
-            error_msg = "Invalid URL 'relative_to' value (relative_to: {}). ".format(relative_to)
+        except ValueError as e:
+            error_msg = "Invalid URL 'relative_to' value (relative_to: {}). ".format(url['relative_to'])
             error_msg += 'Must be a valid attribute declared in SiteConfig class'
             raise utils.YAMLValueError(error_msg)
-        return base_url
 
     def get_page_title(self):
         """Get the title of the current page

--- a/webdriver_test_tools/project/new_file.py
+++ b/webdriver_test_tools/project/new_file.py
@@ -46,7 +46,7 @@ PAGE_OBJECT_TEMPLATE_MAP = {
     },
     COLLAPSIBLE_NAV_PROTOTYPE: {
         'name' : 'collapsible_nav_object',
-        'types': ['py']
+        'types': ['py', 'yml']
     },
     WEB_PAGE_PROTOTYPE: {
         'name' : 'web_page_object',

--- a/webdriver_test_tools/project/new_file.py
+++ b/webdriver_test_tools/project/new_file.py
@@ -42,7 +42,7 @@ PAGE_OBJECT_TEMPLATE_MAP = {
     },
     NAV_PROTOTYPE: {
         'name' : 'nav_object',
-        'types': ['py']
+        'types': ['py', 'yml']
     },
     COLLAPSIBLE_NAV_PROTOTYPE: {
         'name' : 'collapsible_nav_object',

--- a/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.py.j2
@@ -1,15 +1,12 @@
 {% extends "nav_object.py.j2" %}
 
-{% block parent_class %}prototypes.CollapsibleNavObject{% endblock %}
-
-{% block nav_class_prefix %}Collapsible{% endblock %}
 {% block nav_additional_attributes %}
-    # Locator for the button that expands the nav menu
+    # REQUIRED: Locator for the collapsible menu element
+    MENU_LOCATOR = None
+    # REQUIRED: Locator for the button that expands the nav menu
     EXPAND_BUTTON_LOCATOR = None
-    # Locator for the button that expands the nav menu 
-    # (can be the same value as EXPAND_BUTTON_LOCATOR)
+    # (Optional) Locator for the button that collapses the nav menu.
+    # If not set, the value from EXPAND_BUTTON_LOCATOR will be used
     COLLAPSE_BUTTON_LOCATOR = None
-    # Locator for the collapsing/expanding container of the navigation menu
-    MENU_CONTAINER_LOCATOR = None
 {% endblock %}
 

--- a/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.py.j2
@@ -1,6 +1,8 @@
 {% extends "nav_object.py.j2" %}
 
 {% block nav_additional_attributes %}
+    # (Default: False) Whether or not the navbar is collapsible
+    COLLAPSIBLE = True
     # REQUIRED: Locator for the collapsible menu element
     MENU_LOCATOR = None
     # REQUIRED: Locator for the button that expands the nav menu

--- a/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.yml.j2
@@ -1,13 +1,13 @@
 {% extends "nav_object.yml.j2" %}
 
 {% block nav_additional_attributes %}
-  # (Default: false)
+  # (Default: false) Whether the navbar menu is collapsible
   collapsible: true
-  # REQUIRED: Locator for the collapsible menu element
+  # REQUIRED IF COLLAPSIBLE: Locator for the collapsible menu element
   menu_locator:
     by: <BY>
     locator: <LOCATOR>
-  # REQUIRED: Locator for the button that collapses the nav menu
+  # REQUIRED IF COLLAPSIBLE: Locator for the button that collapses the nav menu
   expand_button_locator:
     by: <BY>
     locator: <LOCATOR>

--- a/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/collapsible_nav_object.yml.j2
@@ -1,0 +1,19 @@
+{% extends "nav_object.yml.j2" %}
+
+{% block nav_additional_attributes %}
+  # (Default: false)
+  collapsible: true
+  # REQUIRED: Locator for the collapsible menu element
+  menu_locator:
+    by: <BY>
+    locator: <LOCATOR>
+  # REQUIRED: Locator for the button that collapses the nav menu
+  expand_button_locator:
+    by: <BY>
+    locator: <LOCATOR>
+  # (Optional) Locator for the button that collapses the nav menu.
+  # Uncomment if expand and collapse buttons have different locators
+  # collapse_button_locator:
+  #   by: <BY>
+  #   locator: <LOCATOR>
+{% endblock %}

--- a/webdriver_test_tools/project/templates/templates/page_object/form_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/form_object.yml.j2
@@ -4,15 +4,17 @@
 # REPLACE <PLACEHOLDER VALUES> BELOW AND ADD ITEMS TO THE inputs LIST:
 
 form:
+  # FORM ATTRIBUTES ------------------------------------------------------------
   # REQUIRED: Locator for the form
   form_locator:
-    by: <LOCATE BY>
-    locator: <LOCATOR STRING>
+    by: <BY>
+    locator: <LOCATOR>
   # REQUIRED: Locator for the submit button
   submit_locator:
-    by: <LOCATE BY>
-    locator: <LOCATOR STRING>
-  # List of inputs in the form
+    by: <BY>
+    locator: <LOCATOR>
+  # FORM INPUTS ----------------------------------------------------------------
+  # REQUIRED: List of inputs in the form
   inputs:
     # Example syntax:
     # 

--- a/webdriver_test_tools/project/templates/templates/page_object/modal_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/modal_object.yml.j2
@@ -3,14 +3,13 @@
 
 # REPLACE <PLACEHOLDER VALUES> BELOW:
 
-
 modal:
   # REQUIRED: Locator for the modal
   modal_locator:
-    by: <LOCATE BY>
-    locator: <LOCATOR STRING>
+    by: <BY>
+    locator: <LOCATOR>
   # REQUIRED: Locator for the close button
   close_locator:
-    by: <LOCATE BY>
-    locator: <LOCATOR STRING>
+    by: <BY>
+    locator: <LOCATOR>
 

--- a/webdriver_test_tools/project/templates/templates/page_object/nav_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/nav_object.py.j2
@@ -14,7 +14,7 @@ from {{test_package}}.config import SiteConfig
     SITE_CONFIG = SiteConfig
 
 {% if not use_yaml %}
-    # SET THE FOLLOWING ATTRIBUTES TO USE IN {% block nav_class_prefix %}{% endblock %}NavObject METHODS
+    # SET THE FOLLOWING ATTRIBUTES TO USE IN NavObject METHODS
 
     # REQUIRED: List of link dictionaries. These will be used to initialize
     # NavLinkObject instances at runtime.

--- a/webdriver_test_tools/project/templates/templates/page_object/nav_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/nav_object.py.j2
@@ -1,20 +1,26 @@
-{% extends "base_page.py.j2" %}
+{% if use_yaml %}{% extends "yaml_page.py.j2" %}{% else %}{% extends "base_page.py.j2" %}{% endif %}
+
+{% block additional_imports %}
+
+from {{test_package}}.config import SiteConfig
+{% endblock %}
 
 {% block parent_class %}prototypes.NavObject{% endblock %}
 
 {% block additional_attributes %}
+{% if use_yaml %}{{super()}}
+{% endif %}
+    # Used for internal methods (do not modify)
+    SITE_CONFIG = SiteConfig
+
+{% if not use_yaml %}
     # SET THE FOLLOWING ATTRIBUTES TO USE IN {% block nav_class_prefix %}{% endblock %}NavObject METHODS
 
-    # Maps link text (or any helpful string) to a tuple containing its locator
-    # and the page object class for the target page, modal, section, etc (or
-    # None if need be). E.g.:
-    # LINK_MAP = { 'About': (Locator.ABOUT_LINK, AboutPage), ... }
-    LINK_MAP = {}
-    # Maps link text (or any helpful string) to a tuple containing its locator
-    # and the page object class for the menu, dropdown, etc that should appear
-    # on hover (or None if need be). E.g.:
-    # HOVER_MAP = { 'Products': (Locator.PRODUCTS_LINK, ProductsHoverMenu), ... }
-    HOVER_MAP = {}
+    # REQUIRED: List of link dictionaries. These will be used to initialize
+    # NavLinkObject instances at runtime.
+    # Dictionaries use same keys as YAML links. For syntax, see:
+    # https://connordelacruz.com/webdriver-test-tools/yaml.html#yaml-links
+    LINK_DICTS = []
     {% block nav_additional_attributes %}{% endblock %}
 
     # UNCOMMENT BELOW TO OVERRIDE NavObject DEFAULTS
@@ -23,5 +29,6 @@
     # set to False, click_page_link() and hover_over_page_link() will scroll
     # the target link into view before interacting with it
     # FIXED = True
+{% endif %}
 {% endblock %}
 

--- a/webdriver_test_tools/project/templates/templates/page_object/nav_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/nav_object.py.j2
@@ -28,7 +28,7 @@ from {{test_package}}.config import SiteConfig
     # (Default = True) True if element is a fixed navbar, False otherwise. If
     # set to False, click_page_link() and hover_over_page_link() will scroll
     # the target link into view before interacting with it
-    # FIXED = True
+    # FIXED = False
 {% endif %}
 {% endblock %}
 

--- a/webdriver_test_tools/project/templates/templates/page_object/nav_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/nav_object.yml.j2
@@ -1,0 +1,34 @@
+# NavObject YAML Documentation: 
+# https://connordelacruz.com/webdriver-test-tools/yaml.html#navobjects
+
+# REPLACE <PLACEHOLDER VALUES> BELOW AND ADD ITEMS TO THE links LIST:
+
+
+nav:
+  # (Default: true) Whether the navbar is fixed to the window.
+  # Uncomment to override
+  # fixed: false
+  # List of links in the navbar
+  links:
+    # Example syntax:
+    #
+    # # REQUIRED
+    # - name: <UNIQUE NAME>
+    #   # REQUIRED
+    #   link_locator:
+    #     by: <BY>
+    #     locator: <LOCATOR>
+    #   # (Default: page)
+    #   click: <page, section, menu, none>
+    #   # (Default: none)
+    #   hover: <none, menu>
+    #   # REQUIRED IF 'click' is 'page' or 'section'
+    #   target: <URL, SECTION ID, or RELATIVE URL DICT>
+    #   # REQUIRED IF 'click' or 'hover' is 'menu'
+    #   menu:
+    #     menu_locator:
+    #       by: <BY>
+    #       locator: <LOCATOR>
+    #     links:
+    #       - <SAME SYNTAX AS NAV LINKS>
+

--- a/webdriver_test_tools/project/templates/templates/page_object/nav_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/nav_object.yml.j2
@@ -8,6 +8,8 @@ nav:
   # (Default: true) Whether the navbar is fixed to the window.
   # Uncomment to override
   # fixed: false
+  {% block nav_additional_attributes %}
+  {% endblock %}
   # List of links in the navbar
   links:
     # Example syntax:

--- a/webdriver_test_tools/project/templates/templates/page_object/nav_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/nav_object.yml.j2
@@ -3,14 +3,15 @@
 
 # REPLACE <PLACEHOLDER VALUES> BELOW AND ADD ITEMS TO THE links LIST:
 
-
 nav:
-  # (Default: true) Whether the navbar is fixed to the window.
-  # Uncomment to override
+  # NAV ATTRIBUTES -------------------------------------------------------------
+  # (Default: true) Whether the navbar is fixed to the window. Uncomment to
+  # override
   # fixed: false
   {% block nav_additional_attributes %}
   {% endblock %}
-  # List of links in the navbar
+  # NAV LINKS ------------------------------------------------------------------
+  # REQUIRED: List of links in the navbar
   links:
     # Example syntax:
     #

--- a/webdriver_test_tools/project/templates/templates/page_object/web_page_object.py.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/web_page_object.py.j2
@@ -10,7 +10,7 @@ from {{test_package}}.config import SiteConfig
 {% block additional_attributes %}
 {% if use_yaml %}
 {{super()}}
-    # Used for internal WebPageObject methods (do not modify)
+    # Used for internal methods (do not modify)
     SITE_CONFIG = SiteConfig
 {% else %}
     # File name of the page relative to a base URL declared in SiteConfig

--- a/webdriver_test_tools/project/templates/templates/page_object/web_page_object.yml.j2
+++ b/webdriver_test_tools/project/templates/templates/page_object/web_page_object.yml.j2
@@ -4,7 +4,7 @@
 # SET url KEY BELOW:
 
 web_page:
-  # REQIRED: URL to the page. The following formats are accepted:
+  # REQUIRED: URL to the page. The following formats are accepted:
   # 
   # # Full URL to the page
   # url: http://example.com/
@@ -12,7 +12,7 @@ web_page:
   # url:
   #   # Page path, relative to the SiteConfig attribute specified below
   #   path: path/to/page.html
-  #   # A valid attribute in project SiteConfig to use as the base URL for the page
+  #   # Attribute in project SiteConfig to use as the base URL for the page
   #   relative_to: BASE_URL
-  url:
+  url: 
 


### PR DESCRIPTION
## Pull Request Description

### Overview

Added support for YAML parsing to the `NavObject` prototype, merged functionality of `CollapsibleNavObject` into `NavObject`, and added a new structure for nav links.

### Details

#### `config.site`

* Added class method `parse_relative_url_dicts()` to `SiteConfig`, which takes a URL dict with `path` and `relative_to` keys and returns the full URL based on those

#### `pageobject.nav`

* Added page object classes `NavLinkObject` and `NavMenuObject`, which represent navbar links and dropdown/hover menus of links respectively
* `NavObject` now has attribute `SITE_CONFIG`, which is used to resolve relative URLs
* Deprecated `LINK_MAP` and `HOVER_MAP` in favor of `links` and `YAML_FILE` or `LINK_DICTS`
* Added `COLLAPSIBLE`, `MENU_LOCATOR`, `COLLAPSE_BUTTON_LOCATOR`, and `EXPAND_BUTTON_LOCATOR` attribute to `NavObject`, as well as methods `is_expanded()`, `click_expand_button()`, and `click_collapse_button()`
* Deprecated `click_page_link()` and `hover_over_page_link()` in favor of `click_link()` and `hover_over_link()`
* Deprecated `CollapsibleNavObject` now that functionality has been merged into `NavObject`

#### `pageobject.webpage`

* Implemented `SiteConfig.parse_relative_url_dict()`

#### `project.new_file`

* Updated `nav` and `collapsible nav` to include `.yml` templates

#### `project.templates.templates`

* Updated `nav_object.py.j2` to handle YAML and non-YAML rendering
* Added `nav_object.yml.j2`
* Updated `collapsible_nav_object.py.j2` to support YAML and use `NavObject` prototype class
* Added `collapsible_nav_object.yml.j2`


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update


## Testing

Added test cases for YAML and non-YAML navs, collapsible and regular


## Additional Comments

### Deprecated Items

`NavObject`:

* `LINK_MAP` and `HOVER_MAP` (use `links` and `YAML_FILE` or `LINK_DICTS` instead)
* `click_page_link()` and `hover_over_page_link()` (use `click_link()` and `hover_over_link()` instead

`CollapsibleNavObject`:

* Functionality has been merged with `NavObject`, use that with `COLLAPSIBLE = True` instead

### Future Considerations

The non-YAML workflow for `NavObject` using `LINK_DICTS` is a bit messy and not ideal. Will likely re-work to be cleaner in the future

