### PR TITLE
Test project entry points

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -465,8 +465,8 @@ browsers, use the ``--browser`` (or ``-b``) argument:
 
     <test_package> <args> --browser <browser> [<browser ...]
 
-For a list of options you can specify with ``--browser``, run ``python -m
-<test_package> --help``.
+For a list of options you can specify with ``--browser``, run ``<test_package>
+--help``.
 
 
 Using Headless Browsers

--- a/README.rst
+++ b/README.rst
@@ -235,6 +235,18 @@ This will generate a new test package with template files and project
 directories.
 
 
+(Optional) Setup Virtual Environment
+------------------------------------
+
+If using `virtualenv <https://virtualenv.pypa.io/en/latest/>`_, initialize the
+virtual environment before installing the test package:
+
+::
+   
+   virtualenv venv
+   source ./venv/bin/activate
+
+
 Test Package Installation
 -------------------------
 
@@ -247,8 +259,6 @@ root directory:
 
 Installing with the ``-e`` flag will update the package automatically when
 changes are made to the source code.
-
-**Note:** Command may be ``pip3`` instead of ``pip`` depending on the system
 
 
 Configuration
@@ -267,17 +277,19 @@ Basic Command Line Usage
 
 ::
 
-    python -m <test_package> [-h] <command>
+    <test_package> [-h] <command>
 
-**Note:** If no ``<command>`` is specified, the ``run`` command will be
-executed by default.
+If no ``<command>`` is specified, the ``run`` command will be executed by
+default.
 
+**Note:** If the test package was not installed with ``pip``, run test packages
+commands using ``python -m <test_package> <command>``.
 
 For info on command line arguments, use the ``--help`` (or ``-h``) argument:
 
 ::
 
-    python -m <test_package> --help
+    <test_package> --help
 
 
 Creating New Project Files
@@ -287,7 +299,7 @@ New tests and page objects can be generated using the ``new`` command:
 
 ::
 
-    python -m <test_package> new [<type>] [<module_name>] [<ClassName>] [-d <description>] [-f]
+    <test_package> new [<type>] [<module_name>] [<ClassName>] [-d <description>] [-f]
 
 Where:
 
@@ -309,7 +321,7 @@ New test modules can be generated using the ``new test`` command:
 
 ::
 
-    python -m <test_package> new test <module_name> <TestCaseClass>
+    <test_package> new test <module_name> <TestCaseClass>
 
 Where ``<module_name>`` is the filename for the new test and ``<TestCaseClass>``
 is the class name for the test case.
@@ -320,7 +332,7 @@ the initial test case class:
 
 ::
 
-    python -m <test_package> new test <module_name> <TestCaseClass> -d "Test case description"
+    <test_package> new test <module_name> <TestCaseClass> -d "Test case description"
 
 
 If a test module with the same ``<module_name>`` already exists, ``new test``
@@ -329,7 +341,7 @@ used to force overwrite existing files:
 
 ::
 
-    python -m <test_package> new test <module_name> <TestCaseClass> --force
+    <test_package> new test <module_name> <TestCaseClass> --force
 
 
 Creating New Page Objects
@@ -339,7 +351,7 @@ New page object modules can be generated using the ``new page`` command:
 
 ::
 
-    python -m <test_package> new page <module_name> <PageObjectClass>
+    <test_package> new page <module_name> <PageObjectClass>
 
 Where ``<module_name>`` is the filename for the new module and
 ``<PageObjectClass>`` is the class name for the page object.
@@ -349,7 +361,7 @@ the initial page object class:
 
 ::
 
-    python -m <test_package> new page <module_name> <PageObjectClass> -d "Page object description"
+    <test_package> new page <module_name> <PageObjectClass> -d "Page object description"
 
 By default, the new class will be a generic ``BasePage`` subclass. The
 ``--prototype`` (or ``-p``) argument can be used to specify a `page object
@@ -357,10 +369,10 @@ prototype`_ class to use as a parent class for the new page object:
 
 ::
 
-   python -m <test_package> new page <module_name> <PageObjectClass> -p <prototype>
+   <test_package> new page <module_name> <PageObjectClass> -p <prototype>
 
-For a list of valid ``<prototype>`` options, run ``python -m <test_package>
-new page --help``.
+For a list of valid ``<prototype>`` options, run ``<test_package> new page
+--help``.
 
 .. _page object prototype: https://connordelacruz.com/webdriver-test-tools/utilities.html#page-object-prototypes
 
@@ -375,14 +387,14 @@ can be used to only generate ``.py`` files:
 
 ::
    
-   python -m <test_package> new page <args> --no-yaml
+   <test_package> new page <args> --no-yaml
 
 If ``ENABLE_PAGE_OBJECT_YAML`` is ``False``, the ``--yaml`` (or ``-y``) argument
 can be used to generate ``.py`` and ``.yml`` files for supported prototypes:
 
 ::
 
-   python -m <test_package> new page <args> --yaml
+   <test_package> new page <args> --yaml
 
 .. _Page Object YAML Files documentation: https://connordelacruz.com/webdriver-test-tools/yaml.html
 
@@ -392,7 +404,7 @@ used to force overwrite existing files:
 
 ::
 
-    python -m <test_package> new page <module_name> <PageObjectClass> --force
+    <test_package> new page <module_name> <PageObjectClass> --force
 
 
 Running Tests
@@ -405,7 +417,7 @@ To run all tests:
 
 ::
 
-    python -m <test_package>
+    <test_package>
 
 
 Running Specific Tests
@@ -416,20 +428,20 @@ argument:
 
 ::
 
-    python -m <test_package> --module <test_module> [<test_module> ...]
+    <test_package> --module <test_module> [<test_module> ...]
 
 To run specific test case classes or methods, use the ``--test`` (or ``-t``)
 argument:
 
 ::
 
-    python -m <test_package> --test <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
+    <test_package> --test <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
 To skip certain test cases or methods, use the ``--skip`` (or ``-s``) argument:
 
 ::
 
-    python -m <test_package> --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
+    <test_package> --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
 
 The ``--test`` and ``--skip`` arguments both support wildcards (``*``) in class
@@ -451,7 +463,7 @@ browsers, use the ``--browser`` (or ``-b``) argument:
 
 ::
 
-    python -m <test_package> <args> --browser <browser> [<browser ...]
+    <test_package> <args> --browser <browser> [<browser ...]
 
 For a list of options you can specify with ``--browser``, run ``python -m
 <test_package> --help``.
@@ -469,7 +481,7 @@ To improve performance, tests can be run in `headless browsers`_ using the
 
 ::
 
-    python -m <test_package> <args> --headless
+    <test_package> <args> --headless
 
 **Note:** When using the ``--headless`` argument, tests will only be run with
 the following web drivers that support running in a headless environment:
@@ -489,7 +501,7 @@ BrowserStack support is enabled, tests can be run on BrowserStack using the
 
 ::
 
-    python -m <test_package> <args> --browserstack
+    <test_package> <args> --browserstack
 
 See the documentation on `BrowserStack Support`_ for more details and setup
 instructions.
@@ -506,7 +518,7 @@ suppress output, use the ``--verbosity`` (or ``-v``) argument:
 
 ::
 
-    python -m <test_package> <args> --verbosity <level>
+    <test_package> <args> --verbosity <level>
 
 Where ``<level>`` is one of the following:
 
@@ -526,19 +538,19 @@ To print a list of available test classes and methods:
 
 ::
 
-    python -m <test_package> list
+    <test_package> list
 
 To only list test classes from specific modules:
 
 ::
 
-    python -m <test_package> list --module <test_module> [<test_module> ...]
+    <test_package> list --module <test_module> [<test_module> ...]
 
 To only list specific test classes:
 
 ::
 
-    python -m <test_package> list --test <TestClass> [<TestClass> ...]
+    <test_package> list --test <TestClass> [<TestClass> ...]
 
 
 

--- a/docs/source/browserstack.rst
+++ b/docs/source/browserstack.rst
@@ -68,19 +68,19 @@ examples:
 
 ::
 
-    python -m <test_package> --browserstack
+    <test_package> --browserstack
 
 ::
 
-    python -m <test_package> --module <test_module> --browserstack
+    <test_package> --module <test_module> --browserstack
 
 ::
 
-    python -m <test_package> --test <TestClass> --browserstack
+    <test_package> --test <TestClass> --browserstack
 
 ::
 
-    python -m <test_package> --browser <browser> --browserstack
+    <test_package> --browser <browser> --browserstack
 
 
 Configuring Browsers
@@ -142,7 +142,7 @@ specify the build name for the group of tests being run:
 
 ::
 
-    python -m <test_package> <args> --browserstack --build <name>
+    <test_package> <args> --browserstack --build <name>
 
 **Note:** Quotation marks must be used for build names containing spaces (e.g.
 ``--build 'Example Build'``).
@@ -180,13 +180,13 @@ To enable video recording:
 
 ::
 
-    python -m <test_package> <args> --browserstack --video
+    <test_package> <args> --browserstack --video
 
 To disable video recording:
 
 ::
 
-    python -m <test_package> <args> --browserstack --no-video
+    <test_package> <args> --browserstack --no-video
 
 
 

--- a/docs/source/example_project.rst
+++ b/docs/source/example_project.rst
@@ -11,6 +11,9 @@ example project can be found `here
 Initialize the project
 ----------------------
 
+Create project files
+~~~~~~~~~~~~~~~~~~~~
+
 First, create a directory for the test project:
 
 .. code-block:: none
@@ -77,6 +80,7 @@ Initializing the project should create the following files and directories:
     │   │   ├── __init__.py
     │   │   ├── browser.py
     │   │   ├── browserstack.py
+    │   │   ├── projectfiles.py
     │   │   ├── site.py
     │   │   ├── test.py
     │   │   └── webdriver.py
@@ -89,6 +93,26 @@ Initializing the project should create the following files and directories:
     │       └── __init__.py
     └── setup.py
 
+
+(Optional) Setup virtualenv
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If using ``virtualenv``, initialize the virtual environment before installing
+the test package:
+
+.. code-block:: none
+   
+   virtualenv venv
+   source ./venv/bin/activate
+
+``virtualenv`` allows the test package to be installed in an isolated python
+environment, ensuring any dependencies won't overlap with other packages that
+may require different versions. For more information, see `virtualenv
+documentation <https://virtualenv.pypa.io/en/latest/>`_.
+
+
+Install test package
+~~~~~~~~~~~~~~~~~~~~
 
 After initializing the test project, run:
 
@@ -146,7 +170,7 @@ module:
 
 .. code-block:: none
 
-    python -m example_package new page
+    example_package new page
 
 You will be prompted to enter a name for the new module, a class name for the
 new page object, and an optional description for the page object. We'll call the
@@ -181,7 +205,7 @@ This will create the file ``example_package/pages/home.py``.
 
    ::
 
-      python -m example_package new page --help
+      example_package new page --help
 
 
 Locating page elements
@@ -240,7 +264,7 @@ test case. Run the following command to create a new test module:
 
 .. code-block:: none
 
-    python -m example_package new test
+    example_package new test
 
 You will be prompted to enter a name for the new module, a class name for the
 test case, and an optional description for the test case class. We'll call the
@@ -268,7 +292,7 @@ This will create the file ``example_package/tests/home.py``.
 
    ::
 
-      python -m example_package new test --help
+      example_package new test --help
 
 
 Adding test functions
@@ -314,7 +338,7 @@ framework is able to detect the tests, run:
 
 .. code-block:: none
 
-    python -m example_package list
+    example_package list
 
 This prints a list of test cases and their test methods in the package. The
 output should look like this:
@@ -339,7 +363,7 @@ To run our test suite:
 
 .. code-block:: none
 
-    python -m example_package
+    example_package
 
 This will generate new test case classes for Chrome and Firefox based on the
 test case classes we wrote and run them. If all tests pass, the output should
@@ -369,7 +393,7 @@ arguments, run:
 
 .. code-block:: none
 
-    python -m example_package run --help
+    example_package run --help
 
 Running in a specific browser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -380,7 +404,7 @@ Firefox test cases:
 
 .. code-block:: none
 
-    python -m example_package --browser firefox
+    example_package --browser firefox
 
 Running specific test modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -391,7 +415,7 @@ command line argument. For example, if we just wanted to run
 
 .. code-block:: none
 
-    python -m example_package --module home
+    example_package --module home
 
 Since we only have one test module in this example, this doesn’t do anything
 different than normal, but this can be useful in test projects with multiple
@@ -406,7 +430,7 @@ run HomePageTestCase:
 
 .. code-block:: none
 
-    python -m example_package --test HomePageTestCase
+    example_package --test HomePageTestCase
 
 Since we only have one test case class in this example, this doesn’t do anything
 different than normal, but this can be useful in test projects with multiple
@@ -416,7 +440,7 @@ If we just wanted to run the ``test_more_information_link`` function:
 
 .. code-block:: none
 
-    python -m example_package --test HomePageTestCase.test_more_information_link
+    example_package --test HomePageTestCase.test_more_information_link
 
 The ``--test`` argument also supports wildcards in both the test case class and
 method names. For example, if we wanted to run all test case classes beginning
@@ -424,20 +448,20 @@ with the word ``Home``:
 
 .. code-block:: none
 
-   python -m example_package --test Home*
+   example_package --test Home*
 
 Or if we wanted to run all methods in ``HomePageTestCase`` containing the word
 ``page``:
 
 .. code-block:: none
 
-   python -m example_package --test HomePageTestCase.*page*
+   example_package --test HomePageTestCase.*page*
 
 Or if we wanted to run all test methods ending with the word ``link``:
 
 .. code-block:: none
 
-   python -m example_package --test *.*_link
+   example_package --test *.*_link
 
 Obviously this isn't particularly useful in our simple example, but can allow
 for a lot more control in larger test projects without needing to type out long
@@ -453,7 +477,7 @@ example, if we wanted to run all tests except for the
 
 .. code-block:: none
 
-    python -m example_package --skip HomePageTestCase.test_more_information_link
+    example_package --skip HomePageTestCase.test_more_information_link
 
 Like the ``--test`` argument, ``--skip`` also supports wildcards in class and
 method names. E.g. if we wanted to skip all methods in all test cases that
@@ -461,7 +485,7 @@ contain the word ``page``:
 
 .. code-block:: none
 
-    python -m example_package --skip *.*page*
+    example_package --skip *.*page*
 
 Again, this isn't particularly interesting since we only have 2 test functions,
 but can be useful in larger test projects.
@@ -475,7 +499,7 @@ headless browsers:
 
 .. code-block:: none
 
-    python -m example_package --headless
+    example_package --headless
 
 For more information and a list of compatible browsers, see 
 :ref:`headless browsers documentation <headless-browsers>`. 
@@ -489,13 +513,13 @@ tests:
 
 .. code-block:: none
 
-    python -m example_package --verbosity 1
+    example_package --verbosity 1
 
 To suppress output entirely and just get the final results:
 
 .. code-block:: none
 
-    python -m example_package --verbosity 0
+    example_package --verbosity 0
 
 
 

--- a/docs/source/test_projects.rst
+++ b/docs/source/test_projects.rst
@@ -21,6 +21,18 @@ This will generate a new test package with template files and project
 directories.
 
 
+(Optional) Setup Virtual Environment
+------------------------------------
+
+If using `virtualenv <https://virtualenv.pypa.io/en/latest/>`_, initialize the
+virtual environment before installing the test package:
+
+::
+   
+   virtualenv venv
+   source ./venv/bin/activate
+
+
 Test Package Installation
 -------------------------
 
@@ -33,8 +45,6 @@ root directory:
 
 Installing with the ``-e`` flag will update the package automatically when
 changes are made to the source code.
-
-**Note:** Command may be ``pip3`` instead of ``pip`` depending on the system
 
 
 Configuration
@@ -53,17 +63,19 @@ Basic Command Line Usage
 
 ::
 
-    python -m <test_package> [-h] <command>
+    <test_package> [-h] <command>
 
-**Note:** If no ``<command>`` is specified, the ``run`` command will be
-executed by default.
+If no ``<command>`` is specified, the ``run`` command will be executed by
+default.
 
+**Note:** If the test package was not installed with ``pip``, run test packages
+commands using ``python -m <test_package> <command>``.
 
 For info on command line arguments, use the ``--help`` (or ``-h``) argument:
 
 ::
 
-    python -m <test_package> --help
+    <test_package> --help
 
 
 Creating New Project Files
@@ -73,7 +85,7 @@ New tests and page objects can be generated using the ``new`` command:
 
 ::
 
-    python -m <test_package> new [<type>] [<module_name>] [<ClassName>] [-d <description>] [-f]
+    <test_package> new [<type>] [<module_name>] [<ClassName>] [-d <description>] [-f]
 
 Where:
 
@@ -95,7 +107,7 @@ New test modules can be generated using the ``new test`` command:
 
 ::
 
-    python -m <test_package> new test <module_name> <TestCaseClass>
+    <test_package> new test <module_name> <TestCaseClass>
 
 Where ``<module_name>`` is the filename for the new test and ``<TestCaseClass>``
 is the class name for the test case.
@@ -106,7 +118,7 @@ the initial test case class:
 
 ::
 
-    python -m <test_package> new test <module_name> <TestCaseClass> -d "Test case description"
+    <test_package> new test <module_name> <TestCaseClass> -d "Test case description"
 
 
 If a test module with the same ``<module_name>`` already exists, ``new test``
@@ -115,7 +127,7 @@ used to force overwrite existing files:
 
 ::
 
-    python -m <test_package> new test <module_name> <TestCaseClass> --force
+    <test_package> new test <module_name> <TestCaseClass> --force
 
 
 Creating New Page Objects
@@ -125,7 +137,7 @@ New page object modules can be generated using the ``new page`` command:
 
 ::
 
-    python -m <test_package> new page <module_name> <PageObjectClass>
+    <test_package> new page <module_name> <PageObjectClass>
 
 Where ``<module_name>`` is the filename for the new module and
 ``<PageObjectClass>`` is the class name for the page object.
@@ -135,7 +147,7 @@ the initial page object class:
 
 ::
 
-    python -m <test_package> new page <module_name> <PageObjectClass> -d "Page object description"
+    <test_package> new page <module_name> <PageObjectClass> -d "Page object description"
 
 By default, the new class will be a generic ``BasePage`` subclass. The
 ``--prototype`` (or ``-p``) argument can be used to specify a `page object
@@ -143,10 +155,10 @@ prototype`_ class to use as a parent class for the new page object:
 
 ::
 
-   python -m <test_package> new page <module_name> <PageObjectClass> -p <prototype>
+   <test_package> new page <module_name> <PageObjectClass> -p <prototype>
 
-For a list of valid ``<prototype>`` options, run ``python -m <test_package>
-new page --help``.
+For a list of valid ``<prototype>`` options, run ``<test_package> new page
+--help``.
 
 .. _page object prototype: https://connordelacruz.com/webdriver-test-tools/utilities.html#page-object-prototypes
 
@@ -161,14 +173,14 @@ can be used to only generate ``.py`` files:
 
 ::
    
-   python -m <test_package> new page <args> --no-yaml
+   <test_package> new page <args> --no-yaml
 
 If ``ENABLE_PAGE_OBJECT_YAML`` is ``False``, the ``--yaml`` (or ``-y``) argument
 can be used to generate ``.py`` and ``.yml`` files for supported prototypes:
 
 ::
 
-   python -m <test_package> new page <args> --yaml
+   <test_package> new page <args> --yaml
 
 .. _Page Object YAML Files documentation: https://connordelacruz.com/webdriver-test-tools/yaml.html
 
@@ -178,7 +190,7 @@ used to force overwrite existing files:
 
 ::
 
-    python -m <test_package> new page <module_name> <PageObjectClass> --force
+    <test_package> new page <module_name> <PageObjectClass> --force
 
 
 Running Tests
@@ -191,7 +203,7 @@ To run all tests:
 
 ::
 
-    python -m <test_package>
+    <test_package>
 
 
 Running Specific Tests
@@ -202,20 +214,20 @@ argument:
 
 ::
 
-    python -m <test_package> --module <test_module> [<test_module> ...]
+    <test_package> --module <test_module> [<test_module> ...]
 
 To run specific test case classes or methods, use the ``--test`` (or ``-t``)
 argument:
 
 ::
 
-    python -m <test_package> --test <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
+    <test_package> --test <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
 To skip certain test cases or methods, use the ``--skip`` (or ``-s``) argument:
 
 ::
 
-    python -m <test_package> --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
+    <test_package> --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
 
 The ``--test`` and ``--skip`` arguments both support wildcards (``*``) in class
@@ -237,7 +249,7 @@ browsers, use the ``--browser`` (or ``-b``) argument:
 
 ::
 
-    python -m <test_package> <args> --browser <browser> [<browser ...]
+    <test_package> <args> --browser <browser> [<browser ...]
 
 For a list of options you can specify with ``--browser``, run ``python -m
 <test_package> --help``.
@@ -255,7 +267,7 @@ To improve performance, tests can be run in `headless browsers`_ using the
 
 ::
 
-    python -m <test_package> <args> --headless
+    <test_package> <args> --headless
 
 **Note:** When using the ``--headless`` argument, tests will only be run with
 the following web drivers that support running in a headless environment:
@@ -275,7 +287,7 @@ BrowserStack support is enabled, tests can be run on BrowserStack using the
 
 ::
 
-    python -m <test_package> <args> --browserstack
+    <test_package> <args> --browserstack
 
 See the documentation on `BrowserStack Support`_ for more details and setup
 instructions.
@@ -292,7 +304,7 @@ suppress output, use the ``--verbosity`` (or ``-v``) argument:
 
 ::
 
-    python -m <test_package> <args> --verbosity <level>
+    <test_package> <args> --verbosity <level>
 
 Where ``<level>`` is one of the following:
 
@@ -312,19 +324,19 @@ To print a list of available test classes and methods:
 
 ::
 
-    python -m <test_package> list
+    <test_package> list
 
 To only list test classes from specific modules:
 
 ::
 
-    python -m <test_package> list --module <test_module> [<test_module> ...]
+    <test_package> list --module <test_module> [<test_module> ...]
 
 To only list specific test classes:
 
 ::
 
-    python -m <test_package> list --test <TestClass> [<TestClass> ...]
+    <test_package> list --test <TestClass> [<TestClass> ...]
 
 
 

--- a/docs/source/test_projects.rst
+++ b/docs/source/test_projects.rst
@@ -251,8 +251,8 @@ browsers, use the ``--browser`` (or ``-b``) argument:
 
     <test_package> <args> --browser <browser> [<browser ...]
 
-For a list of options you can specify with ``--browser``, run ``python -m
-<test_package> --help``.
+For a list of options you can specify with ``--browser``, run ``<test_package>
+--help``.
 
 
 Using Headless Browsers

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -105,7 +105,7 @@ argument:
 
 ::
 
-   python -m <test_package> new page <module_name> <PageObjectClass> -p <prototype>
+   <test_package> new page <module_name> <PageObjectClass> -p <prototype>
 
 Where ``<prototype>`` is one of the options listed when calling ``python -m
 <test_package> new page --help``:

--- a/docs/source/yaml.rst
+++ b/docs/source/yaml.rst
@@ -24,8 +24,6 @@ see `Ansible's YAML documentation`_.
 Supported Prototype Classes
 ---------------------------
 
-.. todo Is this section necessary now that all prototypes are supported?
-
 The following prototype classes support YAML parsing:  
 
    * :class:`FormObject <webdriver_test_tools.pageobject.form.FormObject>`
@@ -52,14 +50,14 @@ can be used to only generate ``.py`` files:
 
 ::
    
-   python -m <test_package> new page <args> --no-yaml
+   <test_package> new page <args> --no-yaml
 
 If ``ENABLE_PAGE_OBJECT_YAML`` is ``False``, the ``--yaml`` (or ``-y``) argument
 can be used to generate ``.py`` and ``.yml`` files for supported prototypes:
 
 ::
 
-   python -m <test_package> new page <args> --yaml
+   <test_package> new page <args> --yaml
 
 .. todo briefly go over YAML_FILE attribute
 

--- a/webdriver_test_tools/project/templates/package_root/__main__.py.j2
+++ b/webdriver_test_tools/project/templates/package_root/__main__.py.j2
@@ -3,6 +3,8 @@
 from webdriver_test_tools.project import test_module
 from {{test_package}} import config, tests
 
+def main():
+    test_module.main(tests, config, __package__)
 
 if __name__ == '__main__':
-    test_module.main(tests, config, __package__)
+    main()

--- a/webdriver_test_tools/project/templates/project_root/README.rst.j2
+++ b/webdriver_test_tools/project/templates/project_root/README.rst.j2
@@ -21,6 +21,18 @@ This will generate a new test package with template files and project
 directories.
 
 
+(Optional) Setup Virtual Environment
+------------------------------------
+
+If using `virtualenv <https://virtualenv.pypa.io/en/latest/>`_, initialize the
+virtual environment before installing the test package:
+
+::
+   
+   virtualenv venv
+   source ./venv/bin/activate
+
+
 Test Package Installation
 -------------------------
 
@@ -33,8 +45,6 @@ root directory:
 
 Installing with the ``-e`` flag will update the package automatically when
 changes are made to the source code.
-
-**Note:** Command may be ``pip3`` instead of ``pip`` depending on the system
 
 
 Configuration
@@ -53,17 +63,19 @@ Basic Command Line Usage
 
 ::
 
-    python -m {{test_package}} [-h] <command>
+    {{test_package}} [-h] <command>
 
-**Note:** If no ``<command>`` is specified, the ``run`` command will be
-executed by default.
+If no ``<command>`` is specified, the ``run`` command will be executed by
+default.
 
+**Note:** If the test package was not installed with ``pip``, run test packages
+commands using ``python -m {{test_package}} <command>``.
 
 For info on command line arguments, use the ``--help`` (or ``-h``) argument:
 
 ::
 
-    python -m {{test_package}} --help
+    {{test_package}} --help
 
 
 Creating New Project Files
@@ -73,7 +85,7 @@ New tests and page objects can be generated using the ``new`` command:
 
 ::
 
-    python -m {{test_package}} new [<type>] [<module_name>] [<ClassName>] [-d <description>] [-f]
+    {{test_package}} new [<type>] [<module_name>] [<ClassName>] [-d <description>] [-f]
 
 Where:
 
@@ -95,7 +107,7 @@ New test modules can be generated using the ``new test`` command:
 
 ::
 
-    python -m {{test_package}} new test <module_name> <TestCaseClass>
+    {{test_package}} new test <module_name> <TestCaseClass>
 
 Where ``<module_name>`` is the filename for the new test and ``<TestCaseClass>``
 is the class name for the test case.
@@ -106,7 +118,7 @@ the initial test case class:
 
 ::
 
-    python -m {{test_package}} new test <module_name> <TestCaseClass> -d "Test case description"
+    {{test_package}} new test <module_name> <TestCaseClass> -d "Test case description"
 
 
 If a test module with the same ``<module_name>`` already exists, ``new test``
@@ -115,7 +127,7 @@ used to force overwrite existing files:
 
 ::
 
-    python -m {{test_package}} new test <module_name> <TestCaseClass> --force
+    {{test_package}} new test <module_name> <TestCaseClass> --force
 
 
 Creating New Page Objects
@@ -125,7 +137,7 @@ New page object modules can be generated using the ``new page`` command:
 
 ::
 
-    python -m {{test_package}} new page <module_name> <PageObjectClass>
+    {{test_package}} new page <module_name> <PageObjectClass>
 
 Where ``<module_name>`` is the filename for the new module and
 ``<PageObjectClass>`` is the class name for the page object.
@@ -135,7 +147,7 @@ the initial page object class:
 
 ::
 
-    python -m {{test_package}} new page <module_name> <PageObjectClass> -d "Page object description"
+    {{test_package}} new page <module_name> <PageObjectClass> -d "Page object description"
 
 By default, the new class will be a generic ``BasePage`` subclass. The
 ``--prototype`` (or ``-p``) argument can be used to specify a `page object
@@ -143,10 +155,10 @@ prototype`_ class to use as a parent class for the new page object:
 
 ::
 
-   python -m {{test_package}} new page <module_name> <PageObjectClass> -p <prototype>
+   {{test_package}} new page <module_name> <PageObjectClass> -p <prototype>
 
-For a list of valid ``<prototype>`` options, run ``python -m {{test_package}}
-new page --help``.
+For a list of valid ``<prototype>`` options, run ``{{test_package}} new page
+--help``.
 
 .. _page object prototype: https://connordelacruz.com/webdriver-test-tools/utilities.html#page-object-prototypes
 
@@ -161,14 +173,14 @@ can be used to only generate ``.py`` files:
 
 ::
    
-   python -m {{test_package}} new page <args> --no-yaml
+   {{test_package}} new page <args> --no-yaml
 
 If ``ENABLE_PAGE_OBJECT_YAML`` is ``False``, the ``--yaml`` (or ``-y``) argument
 can be used to generate ``.py`` and ``.yml`` files for supported prototypes:
 
 ::
 
-   python -m {{test_package}} new page <args> --yaml
+   {{test_package}} new page <args> --yaml
 
 .. _Page Object YAML Files documentation: https://connordelacruz.com/webdriver-test-tools/yaml.html
 
@@ -178,7 +190,7 @@ used to force overwrite existing files:
 
 ::
 
-    python -m {{test_package}} new page <module_name> <PageObjectClass> --force
+    {{test_package}} new page <module_name> <PageObjectClass> --force
 
 
 Running Tests
@@ -191,7 +203,7 @@ To run all tests:
 
 ::
 
-    python -m {{test_package}}
+    {{test_package}}
 
 
 Running Specific Tests
@@ -202,20 +214,20 @@ argument:
 
 ::
 
-    python -m {{test_package}} --module <test_module> [<test_module> ...]
+    {{test_package}} --module <test_module> [<test_module> ...]
 
 To run specific test case classes or methods, use the ``--test`` (or ``-t``)
 argument:
 
 ::
 
-    python -m {{test_package}} --test <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
+    {{test_package}} --test <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
 To skip certain test cases or methods, use the ``--skip`` (or ``-s``) argument:
 
 ::
 
-    python -m {{test_package}} --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
+    {{test_package}} --skip <TestClass>[.<test_method>] [<TestClass>[.<test_method>] ...]
 
 
 The ``--test`` and ``--skip`` arguments both support wildcards (``*``) in class
@@ -237,7 +249,7 @@ browsers, use the ``--browser`` (or ``-b``) argument:
 
 ::
 
-    python -m {{test_package}} <args> --browser <browser> [<browser ...]
+    {{test_package}} <args> --browser <browser> [<browser ...]
 
 For a list of options you can specify with ``--browser``, run ``python -m
 {{test_package}} --help``.
@@ -255,7 +267,7 @@ To improve performance, tests can be run in `headless browsers`_ using the
 
 ::
 
-    python -m {{test_package}} <args> --headless
+    {{test_package}} <args> --headless
 
 **Note:** When using the ``--headless`` argument, tests will only be run with
 the following web drivers that support running in a headless environment:
@@ -275,7 +287,7 @@ BrowserStack support is enabled, tests can be run on BrowserStack using the
 
 ::
 
-    python -m {{test_package}} <args> --browserstack
+    {{test_package}} <args> --browserstack
 
 See the documentation on `BrowserStack Support`_ for more details and setup
 instructions.
@@ -292,7 +304,7 @@ suppress output, use the ``--verbosity`` (or ``-v``) argument:
 
 ::
 
-    python -m {{test_package}} <args> --verbosity <level>
+    {{test_package}} <args> --verbosity <level>
 
 Where ``<level>`` is one of the following:
 
@@ -312,19 +324,19 @@ To print a list of available test classes and methods:
 
 ::
 
-    python -m {{test_package}} list
+    {{test_package}} list
 
 To only list test classes from specific modules:
 
 ::
 
-    python -m {{test_package}} list --module <test_module> [<test_module> ...]
+    {{test_package}} list --module <test_module> [<test_module> ...]
 
 To only list specific test classes:
 
 ::
 
-    python -m {{test_package}} list --test <TestClass> [<TestClass> ...]
+    {{test_package}} list --test <TestClass> [<TestClass> ...]
 
 
 

--- a/webdriver_test_tools/project/templates/project_root/README.rst.j2
+++ b/webdriver_test_tools/project/templates/project_root/README.rst.j2
@@ -251,8 +251,8 @@ browsers, use the ``--browser`` (or ``-b``) argument:
 
     {{test_package}} <args> --browser <browser> [<browser ...]
 
-For a list of options you can specify with ``--browser``, run ``python -m
-{{test_package}} --help``.
+For a list of options you can specify with ``--browser``, run ``{{test_package}}
+--help``.
 
 
 Using Headless Browsers

--- a/webdriver_test_tools/project/templates/project_root/gitignore.j2
+++ b/webdriver_test_tools/project/templates/project_root/gitignore.j2
@@ -5,3 +5,5 @@ __pycache__
 *.pyc
 /dist/
 /*.egg-info
+# Virtual environment
+/venv/

--- a/webdriver_test_tools/project/templates/project_root/setup.py.j2
+++ b/webdriver_test_tools/project/templates/project_root/setup.py.j2
@@ -6,7 +6,11 @@ setup(
     name='{{ test_package }}',
     version='0.1.0',
     packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            '{{ test_package }}={{ test_package }}.__main__:main',
+        ]
+    },
     install_requires=[
         'webdriver-test-tools>={{ test_tools_version }}',
-        'selenium>={{ selenium_version }}',
     ])


### PR DESCRIPTION
## Pull Request Description

### Overview

Updated `setup.py` and `__main__.py` templates for test projects to allow commands to be run without `python -m` when installed. Also added brief documentation on using `virtualenv` with test projects.


### Details

#### Project templates

* Added `main()` method to `__main__.py` template. Essentially just extracted the call to `test_module.main()` to a method to allow console script entry points
* Updated `setup.py` to include `console_scripts` entry point to new main method
* Updated `.gitignore` template to include `venv/` directory

#### Docs

* Added brief overview of `virtualenv` setup 
* Updated command line syntax for test projects to omit `python -m`, but added notes explaining that this syntax is used when a test package isn't installed


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)


## Additional Comments

Since the command line entry point required changes to project templates, older projects won't support this by default. The following changes can be made to allow test projects to be called directly from the command line (replacing `<test_package>` with actual package name):

`setup.py`:

```python
...
setup(
    ...
    entry_points={
        'console_scripts': [
            '<test_package>=<test_package>.__main__:main',
        ]
    },
    ...
    )
```

`<test_package>/__main__.py`:

```python
...
def main():
    test_module.main(tests, config, __package__)

if __name__ == '__main__':
    # test_module.main(tests, config, __package__)
    main()
```

