### PR TITLE
Default assertion wait timeout configurations

### DIFF
--- a/webdriver_test_tools/config/webdriver.py
+++ b/webdriver_test_tools/config/webdriver.py
@@ -14,6 +14,10 @@ class WebDriverConfig:
         subdirectory in the webdriver_test_tools package root directory
     :var WebDriverConfig.SCREENSHOT_PATH: Path to the screenshot directory. Defaults
         to the screenshot subdirectory in the webdriver_test_tools package root directory
+    :var WebDriverConfig.DEFAULT_ASSERTION_TIMEOUT: (Default: 10) Default
+        number of seconds for :ref:`WebDriverTestCase assertion methods
+        <assertion-methods>` to wait for expected conditions to occur before
+        test fails
     :var WebDriverConfig.IMPLICIT_WAIT: Implicit wait time for webdriver to poll DOM
 
         .. note::
@@ -53,10 +57,9 @@ class WebDriverConfig:
     _PACKAGE_ROOT = os.path.dirname(os.path.abspath(webdriver_test_tools.__file__))
     LOG_PATH = os.path.join(_PACKAGE_ROOT, 'log')
     SCREENSHOT_PATH = os.path.join(_PACKAGE_ROOT, 'screenshot')
-    # TODO: doc, organize, add to templates
+
     DEFAULT_ASSERTION_TIMEOUT=10
-
-
+    # TODO: Deprecate
     IMPLICIT_WAIT = 0
 
     FIREFOX_KWARGS = {}
@@ -157,6 +160,7 @@ class WebDriverConfig:
     def set_driver_implicit_wait(cls, driver):
         """Returns driver with implicit wait time set"""
         if cls.IMPLICIT_WAIT > 0:
+            # TODO: Deprecation warning
             driver.implicitly_wait(cls.IMPLICIT_WAIT)
         return driver
 

--- a/webdriver_test_tools/config/webdriver.py
+++ b/webdriver_test_tools/config/webdriver.py
@@ -53,6 +53,9 @@ class WebDriverConfig:
     _PACKAGE_ROOT = os.path.dirname(os.path.abspath(webdriver_test_tools.__file__))
     LOG_PATH = os.path.join(_PACKAGE_ROOT, 'log')
     SCREENSHOT_PATH = os.path.join(_PACKAGE_ROOT, 'screenshot')
+    # TODO: doc, organize, add to templates
+    DEFAULT_ASSERTION_TIMEOUT=10
+
 
     IMPLICIT_WAIT = 0
 

--- a/webdriver_test_tools/project/templates/config/webdriver.py.j2
+++ b/webdriver_test_tools/project/templates/config/webdriver.py.j2
@@ -23,6 +23,14 @@ class WebDriverConfig(config.WebDriverConfig):
 
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
 
+    # WebDriverTestCase Configurations
+
+    # (Default: 10) Default number of seconds for WebDriverTestCase assertion
+    # methods to wait for expected conditions to occur before test fails
+    # https://connordelacruz.com/webdriver-test-tools/webdriver_test_tools.testcase.webdriver.html#assertion-methods
+    # DEFAULT_ASSERTION_TIMEOUT = 10
+
+
     # Browser Driver Initialization Arguments
     #
     # NOTE: Logging configurations are set when the corresponding

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -46,8 +46,8 @@ has additional assertions:
 Each of these assertion methods accepts the following optional keyword arguments:
 
 - ``msg``: If specified, used as the error message on failure
-- ``wait_timeout``: (Default = 10) Number of seconds to wait for expected
-  conditions to occur before test fails
+- ``wait_timeout``: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``) Number of
+  seconds to wait for expected conditions to occur before test fails
 
 Some assertions have other optional keyword arguments specific to what they are
 testing. For details, check the documentation for :class:`WebDriverTestCase`.
@@ -94,6 +94,12 @@ class WebDriverTestCase(unittest.TestCase):
         ``True``, don't generate tests for mobile browsers. This can be helpful if the
         layout changes between desktop and mobile viewports would alter the test
         procedures.
+    :var WebDriverTestCase.DEFAULT_ASSERTION_TIMEOUT: (Optional) Default number
+        of seconds for :ref:`WebDriverTestCase assertion methods
+        <assertion-methods>` to wait for expected conditions to occur before
+        test fails. Defaults to the value of ``DEFAULT_ASSERTION_TIMEOUT`` set
+        in the test project's
+        <webdriver_test_tools.config.webdriver.WebDriverConfig>` class
 
     **Browser-specific implementations of this class need to override the following:**
 
@@ -127,13 +133,11 @@ class WebDriverTestCase(unittest.TestCase):
     driver = None
     WebDriverConfig = WebDriverConfig
 
-    # TODO: doc, organize
-    DEFAULT_ASSERTION_TIMEOUT = None
-
     # Test case attributes
     SITE_URL = None
     SKIP_BROWSERS = []
     SKIP_MOBILE = None
+    DEFAULT_ASSERTION_TIMEOUT = None
 
     # Browser implementation attributes
     DRIVER_NAME = None
@@ -164,14 +168,18 @@ class WebDriverTestCase(unittest.TestCase):
         """
         pass
 
-    # TODO: update docs
     def setUp(self):
         """Initialize driver and call ``self.driver.get(self.SITE_URL)``
 
-        If ``self.ENABLE_BS`` is ``False``, ``self.driver`` gets the returned results of
-        :meth:`self.driver_init() <WebDriverTestCase.driver_init>`. If ``self.ENABLE_BS``
-        is ``True``, ``self.driver`` gets the returned results of :meth:`self.bs_driver_init()
+        If ``self.ENABLE_BS`` is ``False``, ``self.driver`` gets the returned
+        results of :meth:`self.driver_init() <WebDriverTestCase.driver_init>`.
+        If ``self.ENABLE_BS`` is ``True``, ``self.driver`` gets the returned
+        results of :meth:`self.bs_driver_init()
         <WebDriverTestCase.bs_driver_init>`
+
+        Also checks if ``self.DEFAULT_ASSERTION_TIMEOUT`` is set and defaults
+        to ``self.WebDriverConfig.DEFAULT_ASSERTION_TIMEOUT`` if it's
+        unspecified
         """
         self.driver = self.bs_driver_init() if self.ENABLE_BS else self.driver_init()
         if not self.DEFAULT_ASSERTION_TIMEOUT or not isinstance(self.DEFAULT_ASSERTION_TIMEOUT, int):
@@ -190,8 +198,6 @@ class WebDriverTestCase(unittest.TestCase):
         :param locator: WebDriver locator tuple in the format ``(By.<attr>, <locator string>)``
         """
         return '("{0}", "{1}")'.format(*locator)
-
-    # TODO: update assertion docstrings
 
     def assertExists(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element doesn't exist

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -127,6 +127,9 @@ class WebDriverTestCase(unittest.TestCase):
     driver = None
     WebDriverConfig = WebDriverConfig
 
+    # TODO: doc, organize
+    DEFAULT_ASSERTION_TIMEOUT = None
+
     # Test case attributes
     SITE_URL = None
     SKIP_BROWSERS = []
@@ -161,6 +164,7 @@ class WebDriverTestCase(unittest.TestCase):
         """
         pass
 
+    # TODO: update docs
     def setUp(self):
         """Initialize driver and call ``self.driver.get(self.SITE_URL)``
 
@@ -170,6 +174,8 @@ class WebDriverTestCase(unittest.TestCase):
         <WebDriverTestCase.bs_driver_init>`
         """
         self.driver = self.bs_driver_init() if self.ENABLE_BS else self.driver_init()
+        if not self.DEFAULT_ASSERTION_TIMEOUT or not isinstance(self.DEFAULT_ASSERTION_TIMEOUT, int):
+            self.DEFAULT_ASSERTION_TIMEOUT = self.WebDriverConfig.DEFAULT_ASSERTION_TIMEOUT
         self.driver.get(self.SITE_URL)
 
     def tearDown(self):
@@ -185,127 +191,145 @@ class WebDriverTestCase(unittest.TestCase):
         """
         return '("{0}", "{1}")'.format(*locator)
 
-    def assertExists(self, element_locator, msg=None, wait_timeout=10):
+    # TODO: update assertion docstrings
+
+    def assertExists(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element doesn't exist
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.existence_change_test(self.driver, element_locator, test_exists=True, wait_timeout=wait_timeout):
             failure_message = 'No elements located using ' + self._locator_string(element_locator)
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertNotExists(self, element_locator, msg=None, wait_timeout=10):
+    def assertNotExists(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element exists
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.existence_change_test(self.driver, element_locator, test_exists=False, wait_timeout=wait_timeout):
             failure_message = 'Elements located using ' + self._locator_string(element_locator)
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertInView(self, element_locator, msg=None, wait_timeout=10):
+    def assertInView(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element isn't scrolled into view
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.in_view_change_test(self.driver, element_locator, wait_timeout=wait_timeout):
             failure_message = 'Element is not scrolled into view'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertNotInView(self, element_locator, msg=None, wait_timeout=10):
+    def assertNotInView(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element is scrolled into view
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if test.in_view_change_test(self.driver, element_locator, wait_timeout=wait_timeout):
             failure_message = 'Element is scrolled into view'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertVisible(self, element_locator, msg=None, wait_timeout=10):
+    def assertVisible(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element isn't visible
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.visibility_change_test(self.driver, element_locator, wait_timeout=wait_timeout):
             failure_message = 'Element is not visible'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertInvisible(self, element_locator, msg=None, wait_timeout=10):
+    def assertInvisible(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element is visible
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.visibility_change_test(self.driver, element_locator, test_visible=False, wait_timeout=wait_timeout):
             failure_message = 'Element is visible'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertEnabled(self, element_locator, msg=None, wait_timeout=10):
+    def assertEnabled(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element is disabled
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.enabled_state_change_test(self.driver, element_locator, test_enabled=True, wait_timeout=wait_timeout):
             failure_message = 'Element is disabled'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertDisabled(self, element_locator, msg=None, wait_timeout=10):
+    def assertDisabled(self, element_locator, msg=None, wait_timeout=None):
         """Fail if element is enabled
 
         :param element_locator: webdriver locator tuple in the format
             ``(by.<attr>, <locator string>)``
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.enabled_state_change_test(self.driver, element_locator, test_enabled=False, wait_timeout=wait_timeout):
             failure_message = 'Element is enabled'
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertUrlChange(self, expected_url, msg=None, wait_timeout=10):
+    def assertUrlChange(self, expected_url, msg=None, wait_timeout=None):
         """Fail if the URL doesn't match the expected URL.
 
         Assertion uses webdriver_test_tools.test.url_change_test() using the
@@ -315,9 +339,11 @@ class WebDriverTestCase(unittest.TestCase):
         :param expected_url: The expected URL
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.url_change_test(self.driver, expected_url, wait_timeout=wait_timeout):
             failure_message = 'Current URL = {}, expected URL = {}'.format(
                 self.driver.current_url, expected_url
@@ -325,7 +351,7 @@ class WebDriverTestCase(unittest.TestCase):
             msg = self._formatMessage(msg, failure_message)
             raise self.failureException(msg)
 
-    def assertBaseUrlChange(self, expected_url, ignore_trailing_slash=True, msg=None, wait_timeout=10):
+    def assertBaseUrlChange(self, expected_url, ignore_trailing_slash=True, msg=None, wait_timeout=None):
         """Fail if the URL (ignoring query strings) doesn't match the expected
         URL.
 
@@ -338,9 +364,11 @@ class WebDriverTestCase(unittest.TestCase):
             '/' in the expected url and current base URL when comparing
         :param msg: (Optional) if specified, used as the error message on
             failure
-        :param wait_timeout: (Default = 10) Number of seconds to wait for
-            expected conditions to occur before test fails
+        :param wait_timeout: (Default = ``self.DEFAULT_ASSERTION_TIMEOUT``)
+            Number of seconds to wait for expected conditions to occur before
+            test fails
         """
+        wait_timeout = wait_timeout or self.DEFAULT_ASSERTION_TIMEOUT
         if not test.base_url_change_test(self.driver, expected_url,
                                          ignore_trailing_slash=ignore_trailing_slash, wait_timeout=wait_timeout):
             failure_message = 'Current base URL = {}, expected base URL = {}'.format(


### PR DESCRIPTION
## Pull Request Description

### Overview

The default `wait_timeout` value for `WebDriverTestCase` assertion methods can now be configured on a per-project and per-test case basis. 

(Added after writing tests for an incredibly slow site and getting tired of setting `wait_timeout` on each assertion)

### Details

* `WebDriverConfig` now has an attribute `DEFAULT_ASSERTION_TIMEOUT`. This is used as the default value of assertion methods' `wait_timeout` parameter unless overridden in the test case
* `WebDriverTestCase` now has an attribute `DEFAULT_ASSERTION_TIMEOUT`. If set in a subclass, this value is used instead of `WebDriverConfig.DEFAULT_ASSERTION_TIMEOUT` as the default `wait_timeout` value
* Assertion methods now set `wait_timeout` to the appropriate default value if the keyword argument is not provided


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update


