### PR TITLE
Screenshot filename format configs

### DIFF
--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -186,6 +186,9 @@ updated in a single place without altering the tests.
 Screenshots
 ===========
 
+Take Screenshot on Test Failure
+-------------------------------
+
 The :meth:`WebDriverTestCase.screenshotOnFail()
 <webdriver_test_tools.testcase.webdriver.WebDriverTestCase.screenshotOnFail>`
 decorator method can be used to save screenshots when a test assertion fails.
@@ -201,9 +204,8 @@ This can be particularly useful when running tests using :ref:`headless browsers
         def test_method(self):
             ...
 
-Screenshots are saved to the directory configured in
-``WebDriverConfig.SCREENSHOT_PATH``, which is set to
-``<test_package>/screenshot/`` by default.
+See :ref:`screenshot-configs` for details on screenshot filename and path
+configurations.
 
 .. note::
 
@@ -211,4 +213,62 @@ Screenshots are saved to the directory configured in
     within a subTest. See the :meth:`method's documentation
     <webdriver_test_tools.testcase.webdriver.WebDriverTestCase.screenshotOnFail>`
     for more information.
+
+
+Take Screenshots During Test Execution
+--------------------------------------
+
+The :meth:`WebDriverTestCase.takeScreenshot()
+<webdriver_test_tools.testcase.webdriver.WebDriverTestCase.takeScreenshot>`
+method can be used to take screenshots at arbitrary points during test
+execution.
+
+.. code-block:: python
+    :caption: Usage example:
+
+    class ExampleTestCase(WebDriverTestCase):
+        ...
+        def test_method(self):
+            ...
+            self.takeScreenshot()
+
+This method accepts optional parameter ``print_filename``, which will print the
+path to the new file to standard output.
+
+See :ref:`screenshot-configs` for details on screenshot filename and path
+configurations.
+
+
+.. _screenshot-configs:
+
+Configure Screenshot Directory and Filename Format
+--------------------------------------------------
+
+Screenshots are saved to the directory configured in
+``WebDriverConfig.SCREENSHOT_PATH``, which is set to
+``<test_package>/screenshot/`` by default.
+
+Screenshot filenames are determined by the format string configured in
+``WebDriverConfig.SCREENSHOT_FILENAME_FORMAT``. The format string can include
+the following parameters:
+
+   * ``{date}``: Replaced with the date the screenshot was taken (YYYY-MM-DD)
+   * ``{time}``: Replaced with the time the screenshot was taken (HHMMSS)
+   * ``{test}``: Replaced with the test method running when screenshot was taken
+   * ``{browser}``: Replaced with the browser used when screenshot was taken
+
+The format string can include '/' directory separators to save screenshots in
+subdirectories of ``WebDriverConfig.SCREENSHOT_PATH``.
+
+.. code-block:: python
+   :caption: Example filename formats:
+ 
+   # The default output format
+   SCREENSHOT_FILENAME_FORMAT = '{date}/{time}-{test}-{browser}.png'
+
+   # Parameters can be used more than once
+   SCREENSHOT_FILENAME_FORMAT = '{date}-{time}/{time}-{test}-{browser}.png'
+
+   # Can include multiple subdirectories
+   SCREENSHOT_FILENAME_FORMAT = '{date}/{time}/{test}/{browser}.png'
 

--- a/webdriver_test_tools/config/webdriver.py
+++ b/webdriver_test_tools/config/webdriver.py
@@ -24,7 +24,8 @@ class WebDriverConfig:
 
             * `{date}`: Replaced with the date the screenshot was taken
               (YYYY-MM-DD)
-            * `{time}`: Replaced with the time the screenshot was taken (HHMM)
+            * `{time}`: Replaced with the time the screenshot was taken
+              (HHMMSS)
             * `{test}`: Replaced with the test method running when screenshot
               was taken
             * `{browser}`: Replaced with the browser used when screenshot was
@@ -206,7 +207,7 @@ class WebDriverConfig:
         now = datetime.now()
         path = cls.SCREENSHOT_FILENAME_FORMAT.format(
             date=now.strftime('%Y-%m-%d'),
-            time=now.strftime('%H%M'),
+            time=now.strftime('%H%M%S'),
             test=test_name,
             browser=browser_name
         )

--- a/webdriver_test_tools/config/webdriver.py
+++ b/webdriver_test_tools/config/webdriver.py
@@ -22,13 +22,13 @@ class WebDriverConfig:
         :attr:`WebDriverConfig.SCREENSHOT_PATH`). The format string can include
         the following parameters:
 
-            * `{date}`: Replaced with the date the screenshot was taken
+            * ``{date}``: Replaced with the date the screenshot was taken
               (YYYY-MM-DD)
-            * `{time}`: Replaced with the time the screenshot was taken
+            * ``{time}``: Replaced with the time the screenshot was taken
               (HHMMSS)
-            * `{test}`: Replaced with the test method running when screenshot
+            * ``{test}``: Replaced with the test method running when screenshot
               was taken
-            * `{browser}`: Replaced with the browser used when screenshot was
+            * ``{browser}``: Replaced with the browser used when screenshot was
               taken
 
         The format string can include '/' directory separators to save

--- a/webdriver_test_tools/config/webdriver.py
+++ b/webdriver_test_tools/config/webdriver.py
@@ -1,5 +1,4 @@
 import os
-import re
 from datetime import datetime
 
 from selenium import webdriver
@@ -12,10 +11,29 @@ from webdriver_test_tools.common.files import create_directory
 class WebDriverConfig:
     """Configurations for webdriver
 
-    :var WebDriverConfig.LOG_PATH: Path to the log directory. Defaults to the log
-        subdirectory in the webdriver_test_tools package root directory
-    :var WebDriverConfig.SCREENSHOT_PATH: Path to the screenshot directory. Defaults
-        to the screenshot subdirectory in the webdriver_test_tools package root directory
+    :var WebDriverConfig.LOG_PATH: Path to the log directory. Defaults to the
+        log subdirectory in the webdriver_test_tools package root directory
+    :var WebDriverConfig.SCREENSHOT_PATH: Path to the screenshot directory.
+        Defaults to the screenshot subdirectory in the webdriver_test_tools
+        package root directory
+    :var WebDriverConfig.SCREENSHOT_FILENAME_FORMAT: (Default:
+        '{date}/{time}-{test}-{browser}.png') Format string used to determine
+        filenames for screenshots (relative to
+        :attr:`WebDriverConfig.SCREENSHOT_PATH`). The format string can include
+        the following parameters:
+
+            * `{date}`: Replaced with the date the screenshot was taken
+              (YYYY-MM-DD)
+            * `{time}`: Replaced with the time the screenshot was taken (HHMM)
+            * `{test}`: Replaced with the test method running when screenshot
+              was taken
+            * `{browser}`: Replaced with the browser used when screenshot was
+              taken
+
+        The format string can include '/' directory separators to save
+        screenshots in subdirectories of
+        :attr:`WebDriverConfig.SCREENSHOT_PATH`.
+
     :var WebDriverConfig.DEFAULT_ASSERTION_TIMEOUT: (Default: 10) Default
         number of seconds for :ref:`WebDriverTestCase assertion methods
         <assertion-methods>` to wait for expected conditions to occur before
@@ -59,9 +77,7 @@ class WebDriverConfig:
     _PACKAGE_ROOT = os.path.dirname(os.path.abspath(webdriver_test_tools.__file__))
     LOG_PATH = os.path.join(_PACKAGE_ROOT, 'log')
     SCREENSHOT_PATH = os.path.join(_PACKAGE_ROOT, 'screenshot')
-
-    # TODO: doc, template, organize
-    SCREENSHOT_FILE_FORMAT = '{date}/{time}-{test}-{browser}.png'
+    SCREENSHOT_FILENAME_FORMAT = '{date}/{time}-{test}-{browser}.png'
 
     DEFAULT_ASSERTION_TIMEOUT=10
     # TODO: Deprecate
@@ -171,45 +187,38 @@ class WebDriverConfig:
 
     # Misc
 
-    # TODO: update docs
     @classmethod
     def new_screenshot_file(cls, browser_name, test_name, makedirs=True):
-        """Return the full filepath and filename for the screenshot
+        """Return the full path and filename for the screenshot
+
+        The filename is determined by the format set in
+        :attr:`WebDriverConfig.SCREENSHOT_FILENAME_FORMAT`. If the format doesn't
+        end with '.png', the extension will be appended to the resulting
+        filename
 
         :param browser_name: Name of the browser (for screenshot filename)
         :param test_name: Name of the current test (for screenshot filename)
+        :param makedirs: (Default = True) If True, create any subdirectories of
+            screenshot/ if they don't already exist
 
         :return: Filename for the screenshot
         """
         now = datetime.now()
-        info = {
-            'date': now.strftime('%Y-%m-%d'),
-            'time': now.strftime('%H%M'),
-            'test': test_name,
-            'browser': browser_name
-        }
-        # TODO: cleanup
-        # filename_fmt = '{time}-{browser}-{test}.png'
-        # timestamp = datetime.now().strftime('%Y%m%d-%H%M')
-        # filename = filename_fmt.format(time=timestamp, browser=browser_name, test=test_name)
-        path = cls.get_screenshot_filename(info)
+        path = cls.SCREENSHOT_FILENAME_FORMAT.format(
+            date=now.strftime('%Y-%m-%d'),
+            time=now.strftime('%H%M'),
+            test=test_name,
+            browser=browser_name
+        )
+        # Ensure .png extension is present
+        if not path.lower().endswith('.png'):
+            path += '.png'
         # Validate string characters for file name
         filename = utils.validate_filename(os.path.basename(path))
+        # Get any subdirectory names
         dirname = os.path.dirname(path)
+        # Create subdirectories if they don't already exist
         if makedirs:
             create_directory(cls.SCREENSHOT_PATH, dirname)
         return os.path.join(cls.SCREENSHOT_PATH, dirname, filename)
-
-    @classmethod
-    def get_screenshot_filename(cls, info):
-        # TODO: doc
-        fmt = cls._screenshot_file_dict_format()
-        return fmt.format(info=info)
-
-    @classmethod
-    def _screenshot_file_dict_format(cls, dict_name='info'):
-        # TODO: doc
-        expr = r'\{(.*?)\}'
-        update_fmt = lambda matchobj : '{{{dict_name}[{key}]}}'.format(dict_name=dict_name, key=matchobj.group(1))
-        return re.sub(expr, update_fmt, cls.SCREENSHOT_FILE_FORMAT)
 

--- a/webdriver_test_tools/project/templates/config/webdriver.py.j2
+++ b/webdriver_test_tools/project/templates/config/webdriver.py.j2
@@ -25,7 +25,7 @@ class WebDriverConfig(config.WebDriverConfig):
     # format string can include the following parameters:
     #
     # {date}: Replaced with the date the screenshot was taken (YYYY-MM-DD)
-    # {time}: Replaced with the time the screenshot was taken (HHMM)
+    # {time}: Replaced with the time the screenshot was taken (HHMMSS)
     # {test}: Replaced with the test method running when screenshot was taken
     # {browser}: Replaced with the browser used when screenshot was taken
     #

--- a/webdriver_test_tools/project/templates/config/webdriver.py.j2
+++ b/webdriver_test_tools/project/templates/config/webdriver.py.j2
@@ -20,6 +20,19 @@ class WebDriverConfig(config.WebDriverConfig):
     # in the webdriver_test_tools package root directory if unspecified
     SCREENSHOT_PATH = os.path.join(_PACKAGE_ROOT, 'screenshot')
 
+    # (Default: '{date}/{time}-{test}-{browser}.png') Format string used to
+    # determine filenames for screenshots (relative to SCREENSHOT_PATH). The
+    # format string can include the following parameters:
+    #
+    # {date}: Replaced with the date the screenshot was taken (YYYY-MM-DD)
+    # {time}: Replaced with the time the screenshot was taken (HHMM)
+    # {test}: Replaced with the test method running when screenshot was taken
+    # {browser}: Replaced with the browser used when screenshot was taken
+    #
+    # The format string can include '/' directory separators to save
+    # screenshots in subdirectories of SCREENSHOT_PATH.
+    SCREENSHOT_FILENAME_FORMAT = '{date}/{time}-{test}-{browser}.png'
+
 
     # UNCOMMENT TO OVERRIDE DEFAULT CONFIGURATIONS
 

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -488,6 +488,7 @@ class WebDriverTestCase(unittest.TestCase):
                 except self.failureException as e:
                     screenshot_file = self.WebDriverConfig.new_screenshot_file(self.SHORT_NAME, self._testMethodName)
                     self.driver.get_screenshot_as_file(screenshot_file)
+                    # TODO: update error message to include screenshot path
                     raise
             return wrapper
         return decorator

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -459,6 +459,23 @@ class WebDriverTestCase(unittest.TestCase):
 
         return decorator
 
+    # Screenshots
+
+    def takeScreenshot(self, print_filename=False):
+        """Capture screenshot and save it to the directory configured in
+        ``WebDriverConfig.SCREENSHOT_PATH``
+
+        :param print_filename: (Default = False) If True, print the path to the
+            new file to standard out
+
+        :return: Path to the new screenshot file
+        """
+        screenshot_file = self.WebDriverConfig.new_screenshot_file(self.SHORT_NAME, self._testMethodName)
+        self.driver.get_screenshot_as_file(screenshot_file)
+        if print_filename:
+            print('Screenshot taken: ' + screenshot_file)
+        return screenshot_file
+
     @staticmethod
     def screenshotOnFail():
         """Decorator for test methods that takes a screenshot if an assertion fails.
@@ -486,8 +503,7 @@ class WebDriverTestCase(unittest.TestCase):
                 try:
                     test_method(self, *args, **kwargs)
                 except self.failureException as e:
-                    screenshot_file = self.WebDriverConfig.new_screenshot_file(self.SHORT_NAME, self._testMethodName)
-                    self.driver.get_screenshot_as_file(screenshot_file)
+                    screenshot_file = self.takeScreenshot()
                     # TODO: update error message to include screenshot path
                     raise
             return wrapper

--- a/webdriver_test_tools/testcase/webdriver.py
+++ b/webdriver_test_tools/testcase/webdriver.py
@@ -462,8 +462,9 @@ class WebDriverTestCase(unittest.TestCase):
     # Screenshots
 
     def takeScreenshot(self, print_filename=False):
-        """Capture screenshot and save it to the directory configured in
-        ``WebDriverConfig.SCREENSHOT_PATH``
+        """Save a screenshot using
+        :meth:`self.WebDriverConfig.new_screenshot_file
+        <webdriver_test_tools.config.webdriver.WebDriverConfig.new_screenshot_file>`
 
         :param print_filename: (Default = False) If True, print the path to the
             new file to standard out
@@ -478,8 +479,10 @@ class WebDriverTestCase(unittest.TestCase):
 
     @staticmethod
     def screenshotOnFail():
-        """Decorator for test methods that takes a screenshot if an assertion fails.
-        Screenshots are saved to the directory configured in ``WebDriverConfig.SCREENSHOT_PATH``
+        """Decorator for test methods that takes a screenshot if an assertion
+        fails. See :meth:`WebDriverConfig.new_screenshot_file
+        <webdriver_test_tools.config.webdriver.WebDriverConfig.new_screenshot_file>`
+        for details on filename and output directory
 
         Usage Example:
 
@@ -493,9 +496,10 @@ class WebDriverTestCase(unittest.TestCase):
 
         .. note::
 
-            Currently, this method does not take a screenshot for assertions that fail within a subTest.
-            Since subTests are designed to continue test execution if an assertion fails, they don't
-            raise exceptions outside of their context.
+            Currently, this method does not take a screenshot for assertions
+            that fail within a subTest. Since subTests are designed to
+            continue test execution if an assertion fails, they don't raise
+            exceptions outside of their context.
         """
         def decorator(test_method):
             @wraps(test_method)


### PR DESCRIPTION
## Pull Request Description

### Overview

Added `WebDriverConfig.SCREENSHOT_FILENAME_FORMAT`, a format string used to specify the output filenames when a file is saved by `WebDriverTestCase.screenshotOnFail()`. The format string supports the following parameters:

* {date}: Replaced with the date the screenshot was taken (YYYY-MM-DD)
* {time}: Replaced with the time the screenshot was taken (HHMMSS)
* {test}: Replaced with the test method running when screenshot was taken
* {browser}: Replaced with the browser used when screenshot was taken

The format string can include '/' directory separators to save screenshots in subdirectories of the configured `SCREENSHOT_PATH`.

Additionally, added `WebDriverTestCase.takeScreenshot()`, which saves a screenshot using the related configurations in `WebDriverTestCase`.


### Details

`WebDriverConfig`:

* Added `SCREENSHOT_FILENAME_FORMAT` attribute
* `new_screenshot_file()` now determines filename based on `SCREENSHOT_FILENAME_INPUT`

`WebDriverTestCase`:

* Added `takeScreenshot()`, which saves a screenshot using the path and filename configurations in `WebDriverConfig`


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)


