### PR TITLE
utils.yaml.parse_locator_dict() now handles normal locators

### DIFF
--- a/test/page-object-tests/page_object_tests/pages/no_yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/no_yaml_nav.py
@@ -22,89 +22,67 @@ class NoYAMLNavObject(prototypes.NavObject):
     # NavLinkObject instances at runtime.
     # Dictionaries use same keys as YAML links. For syntax, see:
     # https://connordelacruz.com/webdriver-test-tools/yaml.html#yaml-links
+
+    # TODO: update to support new syntax
     LINK_DICTS = [
         {
             'name': 'home',
-            'link_locator': {
-                'by': 'CLASS_NAME', 'locator': 'navbar-brand'
-            },
-            'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+            'link_locator': (By.CLASS_NAME, 'navbar-brand'),
+            'target': SiteConfig.BASE_URL + 'index.html'
         },
         {
             'name': 'section3',
-            'link_locator': {
-                'by': 'CSS_SELECTOR', 'locator': 'a[href="#section3"]'
-            },
+            'link_locator': (By.CSS_SELECTOR, 'a[href="#section3"]'),
             'click': 'section',
             'target': '#section3'
         },
         {
             'name': 'hover-menu',
-            'link_locator': {
-                'by': 'ID', 'locator': 'hover-menu-link'
-            },
+            'link_locator': (By.ID, 'hover-menu-link'),
             'click': 'none',
             'hover': 'menu',
             'menu': {
-                'menu_locator': {
-                    'by': 'ID', 'locator': 'hover-menu'
-                },
+                'menu_locator': (By.ID, 'hover-menu'),
                 'links': [
                     {
                         'name': 'home',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#hover-menu a[href="index.html"]'
-                        },
-                        'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#hover-menu a[href="index.html"]'),
+                        'target': SiteConfig.BASE_URL + 'index.html'
                     },
                     {
                         'name': 'form',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#hover-menu a[href="form.html"]'
-                        },
-                        'target': {'path': 'form.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#hover-menu a[href="form.html"]'),
+                        'target': SiteConfig.BASE_URL + 'form.html'
                     },
                     {
                         'name': 'modal',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#hover-menu a[href="modal.html"]'
-                        },
-                        'target': {'path': 'modal.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#hover-menu a[href="modal.html"]'),
+                        'target': SiteConfig.BASE_URL + 'modal.html'
                     },
                 ]
             }
         },
         {
             'name': 'click-menu',
-            'link_locator': {
-                'by': 'ID', 'locator': 'click-menu-link'
-            },
+            'link_locator': (By.ID, 'click-menu-link'),
             'click': 'menu',
             'menu': {
-                'menu_locator': {
-                    'by': 'ID', 'locator': 'click-menu'
-                },
+                'menu_locator': (By.ID, 'click-menu'),
                 'links': [
                     {
                         'name': 'home',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="index.html"]'
-                        },
-                        'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#click-menu a[href="index.html"]'),
+                        'target': SiteConfig.BASE_URL + 'index.html'
                     },
                     {
                         'name': 'form',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="form.html"]'
-                        },
-                        'target': {'path': 'form.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#click-menu a[href="form.html"]'),
+                        'target': SiteConfig.BASE_URL + 'form.html'
                     },
                     {
                         'name': 'modal',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="modal.html"]'
-                        },
-                        'target': {'path': 'modal.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#click-menu a[href="modal.html"]'),
+                        'target': SiteConfig.BASE_URL + 'modal.html'
                     },
                 ]
             }
@@ -139,50 +117,36 @@ class NoYAMLCollapsibleNavObject(prototypes.NavObject):
     LINK_DICTS = [
         {
             'name': 'home',
-            'link_locator': {
-                'by': 'CLASS_NAME', 'locator': 'navbar-brand'
-            },
-            'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+            'link_locator': (By.CLASS_NAME, 'navbar-brand'),
+            'target': SiteConfig.BASE_URL + 'index.html'
         },
         {
             'name': 'section3',
-            'link_locator': {
-                'by': 'CSS_SELECTOR', 'locator': 'a[href="#section3"]'
-            },
+            'link_locator': (By.CSS_SELECTOR, 'a[href="#section3"]'),
             'click': 'section',
             'target': '#section3'
         },
         {
             'name': 'click-menu',
-            'link_locator': {
-                'by': 'ID', 'locator': 'click-menu-link'
-            },
+            'link_locator': (By.ID, 'click-menu-link'),
             'click': 'menu',
             'menu': {
-                'menu_locator': {
-                    'by': 'ID', 'locator': 'click-menu'
-                },
+                'menu_locator': (By.ID, 'click-menu'),
                 'links': [
                     {
                         'name': 'home',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="index.html"]'
-                        },
-                        'target': {'path': 'index.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#click-menu a[href="index.html"]'),
+                        'target': SiteConfig.BASE_URL + 'index.html'
                     },
                     {
                         'name': 'form',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="form.html"]'
-                        },
-                        'target': {'path': 'form.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#click-menu a[href="form.html"]'),
+                        'target': SiteConfig.BASE_URL + 'form.html'
                     },
                     {
                         'name': 'modal',
-                        'link_locator': {
-                            'by': 'CSS_SELECTOR', 'locator': '#click-menu a[href="modal.html"]'
-                        },
-                        'target': {'path': 'modal.html', 'relative_to': 'BASE_URL'}
+                        'link_locator': (By.CSS_SELECTOR, '#click-menu a[href="modal.html"]'),
+                        'target': SiteConfig.BASE_URL + 'modal.html'
                     },
                 ]
             }

--- a/webdriver_test_tools/pageobject/utils/yaml.py
+++ b/webdriver_test_tools/pageobject/utils/yaml.py
@@ -37,6 +37,10 @@ def parse_locator_dict(locator_dict):
     """Takes a locator dictionary from a parsed YAML file and returns the
     locator tuple
 
+    If ``locator_dict`` is already a tuple, it will be returned as-is under the
+    assumption that it's already a locator. This allows non-YAML
+    representations to just use normal locators
+
     :param locator_dict: Locator dictionary from a parsed YAML file. A valid
         locator dict must have the following keys:
 
@@ -50,6 +54,9 @@ def parse_locator_dict(locator_dict):
 
     :return: Parsed WebDriver locator tuple
     """
+    # If argument is already a tuple, return it assuming it's already a locator
+    if isinstance(locator_dict, tuple):
+        return locator_dict
     try:
         locate_by_attr = locator_dict['by'].upper()
         locate_by = getattr(By, locate_by_attr)


### PR DESCRIPTION
## Pull Request Description

### Overview

If a tuple is passed to `pageobject.utils.yaml.parse_locator_dict()`, it's immediately returned as it's assumed to already be a locator. This allows non-YAML representations of page objects to just use normal locators.


### Details

* Updated `pageobject.utils.yaml.parse_locator_dict()` to handle normal locators in addition to locator dictionaries
* Updated non-YAML navbar tests to use normal locators in place of dictionaries


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update


## Testing

Updated non-YAML nav object tests to use locator tuples instead of dictionaries.

## Additional Comments

Documentation on this will be added in a future update along with specific syntax (YAML and non-YAML) of each page object prototype
