### PR TITLE
Collapsible variants of existing NavObjects

### DIFF
--- a/test/page-object-tests/page_object_tests/pages/yaml_nav.py
+++ b/test/page-object-tests/page_object_tests/pages/yaml_nav.py
@@ -8,6 +8,7 @@ from page_object_tests.config import SiteConfig
 
 
 class YAMLNavObject(prototypes.NavObject):
+    """Regular nav object"""
 
     PAGE_FILENAME = 'navbar.html'
 
@@ -27,6 +28,7 @@ class YAMLNavObject(prototypes.NavObject):
 
 
 class YAMLCollapsibleNavObject(prototypes.NavObject):
+    """Collapsible nav object"""
 
     PAGE_FILENAME = 'collapsible_navbar.html'
 
@@ -42,4 +44,13 @@ class YAMLCollapsibleNavObject(prototypes.NavObject):
     # Used for internal methods (do not modify)
     SITE_CONFIG = SiteConfig
 
+
+class YAMLNavObjectCollapsibleSubclass(YAMLNavObject):
+    """Collapsible nav subclassing a YAML parsing non-collapsible nav"""
+
+    PAGE_FILENAME = 'collapsible_navbar.html'
+
+    COLLAPSIBLE = True
+    MENU_LOCATOR = (By.ID, 'nav-menu')
+    EXPAND_BUTTON_LOCATOR = (By.ID, 'navbar-toggle')
 

--- a/test/page-object-tests/page_object_tests/tests/nav.py
+++ b/test/page-object-tests/page_object_tests/tests/nav.py
@@ -4,7 +4,7 @@ import webdriver_test_tools
 from webdriver_test_tools.testcase import *
 
 from page_object_tests import config
-from page_object_tests.pages.yaml_nav import YAMLNavObject, YAMLCollapsibleNavObject
+from page_object_tests.pages.yaml_nav import YAMLNavObject, YAMLCollapsibleNavObject, YAMLNavObjectCollapsibleSubclass
 from page_object_tests.pages.no_yaml_nav import NoYAMLNavObject, NoYAMLCollapsibleNavObject
 
 
@@ -63,6 +63,11 @@ class CollapsibleNavObjectTestCase(WebDriverTestCase):
     def test_nav_object_no_yaml(self):
         """(Collapsible) Test links for pages and sections and click dropdowns (no YAML)"""
         nav_object = NoYAMLCollapsibleNavObject(self.driver)
+        self._test_nav_object(nav_object)
+
+    def test_nav_object_collapsible_subclass(self):
+        """(Collapsible) Test links for pages and sections and click dropdowns (subclass of YAML)"""
+        nav_object = YAMLNavObjectCollapsibleSubclass(self.driver)
         self._test_nav_object(nav_object)
 
     def _test_nav_object(self, nav_object):

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -223,6 +223,7 @@ class NavMenuObject(BasePage):
 
 # Navbar Page Objects
 
+# TODO: document subclassing for collapsible
 class NavObject(YAMLParsingPageObject):
     """Page object prototype for navbars
 
@@ -340,9 +341,14 @@ class NavObject(YAMLParsingPageObject):
         # Collapsible nav configurations
         if self.COLLAPSIBLE:
             try:
-                self.MENU_LOCATOR = utils.yaml.parse_locator_dict(parsed_yaml['menu_locator'])
-                self.EXPAND_BUTTON_LOCATOR = utils.yaml.parse_locator_dict(parsed_yaml['expand_button_locator'])
-                if 'collapse_button_locator' in parsed_yaml:
+                # Only do the following if these elements weren't explicitly
+                # defined in the class. This allows for collapsible variants of
+                # existing nav classes to be defined using subclasses
+                if self.MENU_LOCATOR is None:
+                    self.MENU_LOCATOR = utils.yaml.parse_locator_dict(parsed_yaml['menu_locator'])
+                if self.EXPAND_BUTTON_LOCATOR is None:
+                    self.EXPAND_BUTTON_LOCATOR = utils.yaml.parse_locator_dict(parsed_yaml['expand_button_locator'])
+                if self.COLLAPSE_BUTTON_LOCATOR is None and 'collapse_button_locator' in parsed_yaml:
                     self.COLLAPSE_BUTTON_LOCATOR = utils.yaml.parse_locator_dict(parsed_yaml['collapse_button_locator'])
                 else:
                     self.COLLAPSE_BUTTON_LOCATOR = self.EXPAND_BUTTON_LOCATOR

--- a/webdriver_test_tools/pageobject/nav.py
+++ b/webdriver_test_tools/pageobject/nav.py
@@ -223,7 +223,6 @@ class NavMenuObject(BasePage):
 
 # Navbar Page Objects
 
-# TODO: document subclassing for collapsible
 class NavObject(YAMLParsingPageObject):
     """Page object prototype for navbars
 
@@ -258,6 +257,16 @@ class NavObject(YAMLParsingPageObject):
     :var NavObject.COLLAPSE_BUTTON_LOCATOR: (Optional) Locator for the button
         that collapses the nav menu. If unspecified, this will be set to the
         same value as :attr:`EXPAND_BUTTON_LOCATOR`
+
+    .. note::
+
+        ``MENU_LOCATOR``, ``EXPAND_BUTTON_LOCATOR``, and
+        ``COLLAPSE_BUTTON_LOCATOR`` will only be parsed from YAML if not
+        already set in the subclass. This allows for a non-collapsible nav that
+        parses YAML to be extended in a subclass with ``COLLAPSIBLE = True``
+        without re-writing the YAML file. The subclass would only need to set
+        ``MENU_LOCATOR``, ``EXPAND_BUTTON_LOCATOR``, and (optionally)
+        ``COLLAPSE_BUTTON_LOCATOR``
 
     The following attribute is set based on the 'links' key parsed from
     :attr:`YAML_FILE` (or parsed from :attr:`LINK_DICTS`, which should be set


### PR DESCRIPTION
## Pull Request Description

### Overview

A collapsible variant of an existing non-collapsible nav object that parses YAML can now be created using a subclass. E.g.:

```python
class PrimaryNav(prototypes.NavObject):
    # Path to YAML file representing the object
    YAML_FILE = os.path.join(os.path.dirname(__file__), 'primary_nav.yml')
    # Used for internal methods (do not modify)
    SITE_CONFIG = SiteConfig

class MobilePrimaryNav(YAMLNavObject):
    COLLAPSIBLE = True
    MENU_LOCATOR = (By.ID, 'nav-menu')
    EXPAND_BUTTON_LOCATOR = (By.ID, 'navbar-toggle')
```

### Details

`NavObject.parse_yaml()` now only retrieves 'menu_locator', 'expand_button_locator', and (optionally) 'collapse_button_locator' if the corresponding attributes aren't explicitly set in the class. This allows code to be reused from a non-collapsible nav to create a collapsible variant

## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update


## Testing

Added test case for collapsible subclass of non-collapsible YAML nav object
