### PR TITLE
list command verbose output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -540,6 +540,12 @@ To print a list of available test classes and methods:
 
     <test_package> list
 
+To include docstrings for each test class and method in output:
+
+::
+
+    <test_package> list --verbose
+
 To only list test classes from specific modules:
 
 ::
@@ -552,6 +558,11 @@ To only list specific test classes:
 
     <test_package> list --test <TestClass> [<TestClass> ...]
 
+To skip certain test classes in output:
+
+::
+
+    <test_package> --skip <TestClass> [<TestClass> ...]
 
 
 Project Structure

--- a/docs/source/example_project.rst
+++ b/docs/source/example_project.rst
@@ -345,9 +345,23 @@ output should look like this:
 
 .. code-block:: none
 
-    HomePageTestCase:
-       test_more_information_link
-       test_page_heading
+   home:
+      HomePageTestCase:
+         test_more_information_link
+         test_page_heading
+
+You can also run ``example_package list --verbose`` to view the docstring for
+each class and method:
+
+.. code-block:: none
+
+   home:
+   └── HomePageTestCase:
+       Really contrived example test case
+       ├── test_more_information_link
+       │   Test that the 'More information...' link goes to the correct URL
+       └── test_page_heading
+           Ensure that the page heading text is correct
 
 
 Run the tests

--- a/docs/source/test_projects.rst
+++ b/docs/source/test_projects.rst
@@ -326,6 +326,12 @@ To print a list of available test classes and methods:
 
     <test_package> list
 
+To include docstrings for each test class and method in output:
+
+::
+
+    <test_package> list --verbose
+
 To only list test classes from specific modules:
 
 ::
@@ -338,6 +344,11 @@ To only list specific test classes:
 
     <test_package> list --test <TestClass> [<TestClass> ...]
 
+To skip certain test classes in output:
+
+::
+
+    <test_package> --skip <TestClass> [<TestClass> ...]
 
 
 Project Structure

--- a/webdriver_test_tools/common/cmd/cmd.py
+++ b/webdriver_test_tools/common/cmd/cmd.py
@@ -75,11 +75,11 @@ def print_shortened(text, placeholder='...', indent='', fmt=None):
         printing the text
     """
     width = _term.width - len(indent)
-    text = textwrap.indent(textwrap.shorten(text, width=width, placeholder=placeholder),
-                           indent)
-    # Get fmt method
     fmt_method = COLORS.get(fmt, str)
-    print(fmt_method(text))
+    text = textwrap.indent(
+        fmt_method(textwrap.shorten(text, width=width, placeholder=placeholder)),
+        indent)
+    print(text)
 
 
 # User Input

--- a/webdriver_test_tools/common/cmd/cmd.py
+++ b/webdriver_test_tools/common/cmd/cmd.py
@@ -5,8 +5,9 @@
 """
 # TODO: rename to something less confusing than cmd.cmd
 
-import re
 import os
+import re
+import textwrap
 from blessings import Terminal
 
 # Formatting
@@ -53,6 +54,32 @@ def print_info(text):
     :param text: Info message to print
     """
     print(COLORS['info'](text))
+
+
+def print_shortened(text, placeholder='...', indent='', fmt=None):
+    """Print a string, shorten if it's longer than the current terminal width
+
+    Essentially a wrapper around :meth:`textwrap.shorten` (and optionally
+    :meth:`textwrap.indent`) that truncates based on the terminal width
+
+    If the printed string should be formatted, it is recommended to set the
+    ``fmt`` parameter instead of passing in a formatted string. If a formatted
+    string is truncated, then the colors aren't reset, causing subsequent
+    terminal output to be formatted as well
+
+    :param text: Text to print
+    :param placeholder: (Default = '...') Placeholder to use when truncating
+        the string
+    :param indent: (Optional) If set, indent using this string
+    :param fmt: (Optional) A key in :const:`COLORS` to use for formatting when
+        printing the text
+    """
+    width = _term.width - len(indent)
+    text = textwrap.indent(textwrap.shorten(text, width=width, placeholder=placeholder),
+                           indent)
+    # Get fmt method
+    fmt_method = COLORS.get(fmt, str)
+    print(fmt_method(text))
 
 
 # User Input

--- a/webdriver_test_tools/project/cmd/list.py
+++ b/webdriver_test_tools/project/cmd/list.py
@@ -116,9 +116,7 @@ def _print_test_case(test_class, verbose=False, indent=cmd.INDENT):
     """
     print(textwrap.indent(cmd.COLORS['title'](test_class.__name__) + ':', indent))
     if verbose and hasattr(test_class, '__doc__'):
-        # TODO: common.cmd method to truncate string based on terminal size
-        case_info = textwrap.shorten(test_class.__doc__, width=20, placeholder='...')
-        print(textwrap.indent(cmd.COLORS['info'](case_info), indent))
+        cmd.print_shortened(test_class.__doc__, indent=indent, fmt='info')
     methods = unittest.loader.getTestCaseNames(test_class, 'test')
     for method in methods:
         _print_method(method, test_class=test_class, verbose=verbose)
@@ -139,7 +137,5 @@ def _print_method(method, test_class, verbose=False, indent=cmd.INDENT*2):
         # TODO: catch attribute error
         func = getattr(test_class, method)
         if hasattr(func, '__doc__'):
-            # TODO: common.cmd method to truncate string based on terminal size
-            method_info = textwrap.shorten(func.__doc__, width=20, placeholder='...')
-            print(textwrap.indent(cmd.COLORS['info'](method_info), indent))
+            cmd.print_shortened(func.__doc__, indent=indent, fmt='info')
 

--- a/webdriver_test_tools/project/cmd/list.py
+++ b/webdriver_test_tools/project/cmd/list.py
@@ -41,9 +41,10 @@ def parse_list_args(tests_module, args):
     list_tests(tests_module, **kwargs)
 
 
-# TODO: params for verbosity
+# TODO: params for verbosity default to False
 def list_tests(tests_module,
-               test_module_names=None, test_class_map=None, skip_class_map=None):
+               test_module_names=None, test_class_map=None, skip_class_map=None,
+               verbose=True):
     """Print a list of available tests
 
     :param tests_module: The module object for ``<test_project>.tests``
@@ -57,13 +58,7 @@ def list_tests(tests_module,
     tests = load_tests(tests_module, test_module_names, test_class_map, skip_class_map)
     module_map = _module_map(tests, tests_module)
     for module, test_list in module_map.items():
-        print(cmd.COLORS['prompt'](module) + ':')
-        for test_class in test_list:
-            print(textwrap.indent(cmd.COLORS['title'](test_class.__name__) + ':', cmd.INDENT))
-            test_cases = unittest.loader.getTestCaseNames(test_class, 'test')
-            print(*[
-                textwrap.indent(test_case, cmd.INDENT * 2) for test_case in test_cases
-            ], sep='\n')
+        _print_module(module, test_list, verbose=verbose)
 
 
 def _module_map(tests, tests_module):
@@ -84,3 +79,29 @@ def _module_map(tests, tests_module):
             module_map[module] = []
         module_map[module].append(test)
     return module_map
+
+
+def _print_module(module, test_list, verbose=False):
+    # TODO: doc
+    print(cmd.COLORS['prompt'](module) + ':')
+    for test_class in test_list:
+        _print_test_case(test_class, verbose=verbose)
+
+
+def _print_test_case(test_class, verbose=False):
+    # TODO: doc, indent param?
+    print(textwrap.indent(cmd.COLORS['title'](test_class.__name__) + ':', cmd.INDENT))
+    if verbose and hasattr(test_class, '__doc__'):
+        # TODO: common.cmd method to truncate string based on terminal size
+        case_info = textwrap.shorten(test_class.__doc__, width=20, placeholder='...')
+        print(textwrap.indent(cmd.COLORS['info'](case_info), cmd.INDENT))
+    methods = unittest.loader.getTestCaseNames(test_class, 'test')
+    for method in methods:
+        _print_method(method, verbose=verbose)
+
+
+def _print_method(method, verbose=False):
+    # TODO: doc, indent param?
+    print(textwrap.indent(method, cmd.INDENT * 2))
+    # TODO: figure out how to get docstring (currently only retrieving names, not methods)
+

--- a/webdriver_test_tools/project/cmd/list.py
+++ b/webdriver_test_tools/project/cmd/list.py
@@ -20,7 +20,6 @@ def add_list_subparser(subparsers, parents=[],
     """
     list_description = 'Print a list of available tests and exit'
     list_help = list_description
-    # TODO: aliases=['ls']
     list_parser = subparsers.add_parser(
         'list', description=list_description, help=list_help,
         parents=parents,  # TODO: always use test_parent_parser?
@@ -42,21 +41,46 @@ def parse_list_args(tests_module, args):
     list_tests(tests_module, **kwargs)
 
 
+# TODO: params for verbosity
 def list_tests(tests_module,
                test_module_names=None, test_class_map=None, skip_class_map=None):
     """Print a list of available tests
 
     :param tests_module: The module object for ``<test_project>.tests``
-    :param test_module_names: (Optional) Parsed arg for ``--module`` command line
-        argument
-    :param test_class_map: (Optional) Result of passing parsed arg for ``--test``
-        command line argument to :func:`parse_test_names()`
-    :param skip_class_map: (Optional) Result of passing parsed arg for ``--skip``
-        command line argument to :func:`parse_test_names()`
+    :param test_module_names: (Optional) Parsed arg for ``--module`` command
+        line argument
+    :param test_class_map: (Optional) Result of passing parsed arg for
+        ``--test`` command line argument to :func:`parse_test_names()`
+    :param skip_class_map: (Optional) Result of passing parsed arg for
+        ``--skip`` command line argument to :func:`parse_test_names()`
     """
     tests = load_tests(tests_module, test_module_names, test_class_map, skip_class_map)
-    for test_class in tests:
-        print(cmd.COLORS['title'](test_class.__name__) + ':')
-        test_cases = unittest.loader.getTestCaseNames(test_class, 'test')
-        for test_case in test_cases:
-            print(textwrap.indent(test_case, cmd.INDENT))
+    module_map = _module_map(tests, tests_module)
+    for module, test_list in module_map.items():
+        print(cmd.COLORS['prompt'](module) + ':')
+        for test_class in test_list:
+            print(textwrap.indent(cmd.COLORS['title'](test_class.__name__) + ':', cmd.INDENT))
+            test_cases = unittest.loader.getTestCaseNames(test_class, 'test')
+            print(*[
+                textwrap.indent(test_case, cmd.INDENT * 2) for test_case in test_cases
+            ], sep='\n')
+
+
+def _module_map(tests, tests_module):
+    """Returns a dictionary mapping test module names to a list of the test
+    case classes in the module
+
+    :param tests: List of test case classes
+    :param tests_module: The module object for ``<test_project>.tests``
+
+    :return: Dictionary mapping test module names to a list of the test
+        case classes in the module
+    """
+    module_prefix = tests_module.__name__ + '.'
+    module_map = {}
+    for test in tests:
+        module = test.__module__.replace(module_prefix, '')
+        if module not in module_map:
+            module_map[module] = []
+        module_map[module].append(test)
+    return module_map

--- a/webdriver_test_tools/project/templates/project_root/README.rst.j2
+++ b/webdriver_test_tools/project/templates/project_root/README.rst.j2
@@ -326,6 +326,12 @@ To print a list of available test classes and methods:
 
     {{test_package}} list
 
+To include docstrings for each test class and method in output:
+
+::
+
+    {{test_package}} list --verbose
+
 To only list test classes from specific modules:
 
 ::
@@ -338,6 +344,11 @@ To only list specific test classes:
 
     {{test_package}} list --test <TestClass> [<TestClass> ...]
 
+To skip certain test classes in output:
+
+::
+
+    {{test_package}} --skip <TestClass> [<TestClass> ...]
 
 
 Project Structure


### PR DESCRIPTION
## Pull Request Description

### Overview

`<test_project> list` now displays module names in addition to classes and methods. Additionally, the `--verbose` flag was added, which prints test docstrings and outputs using tree characters e.g.:

```
home:
└── HomePageTestCase:
    Really contrived example test case
    ├── test_more_information_link
    │   Test that the 'More information...' link goes to the correct URL
    └── test_page_heading
        Ensure that the page heading text is correct
```

### Details

`common.cmd`:

* Added `print_shortened()`, which truncates strings longer than the terminal width

`project.cmd.list`:

* Added `--verbose` flag to `list` command. If used, docstrings for test cases and methods will be printed
* `list` now shows modules in addition to test classes and methods
* Re-worked internals of how list prints stuff


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)

