### PR TITLE
Implemented --skip-module test parser flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -430,6 +430,13 @@ argument:
 
     <test_package> --module <test_module> [<test_module> ...]
 
+To skip all test cases in one or more modules, use the ``--skip-module`` (or
+``-S``) argument:
+
+::
+
+    <test_package> --skip-module <test_module> [<test_module> ...]
+
 To run specific test case classes or methods, use the ``--test`` (or ``-t``)
 argument:
 
@@ -450,9 +457,10 @@ and method names.
 These arguments can be used together. When combined, they are processed in the
 following order:
 
-    1. ``--module`` reduces the set of tests to those in the specified modules
-    2. ``--test`` reduces the set of tests to the specified classes and methods
-    3. ``--skip`` removes the specified classes and methods from the set of tests
+    #. ``--skip-module`` removes the specified modules from the set of tests
+    #. ``--module`` reduces the set of tests to those in the specified modules
+    #. ``--test`` reduces the set of tests to the specified classes and methods
+    #. ``--skip`` removes the specified classes and methods from the set of tests
 
 
 Using Specific Browsers
@@ -534,6 +542,9 @@ attribute of the ``TestSuiteConfig`` class.
 List Available Tests
 --------------------
 
+Basic Usage
+~~~~~~~~~~~
+
 To print a list of available test classes and methods:
 
 ::
@@ -546,11 +557,21 @@ To include docstrings for each test class and method in output:
 
     <test_package> list --verbose
 
+
+Listing Specific Tests
+~~~~~~~~~~~~~~~~~~~~~~
+
 To only list test classes from specific modules:
 
 ::
 
     <test_package> list --module <test_module> [<test_module> ...]
+
+To omit specific modules:
+
+::
+
+    <test_package> list --skip-module <test_module> [<test_module> ...]
 
 To only list specific test classes:
 
@@ -563,6 +584,8 @@ To skip certain test classes in output:
 ::
 
     <test_package> --skip <TestClass> [<TestClass> ...]
+
+See `Running Specific Tests`_ for more info on these arguments.
 
 
 Project Structure

--- a/docs/source/example_project.rst
+++ b/docs/source/example_project.rst
@@ -423,8 +423,8 @@ Firefox test cases:
 Running specific test modules
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If we only want to run a specific test module, we can use the ``--module``
-command line argument. For example, if we just wanted to run
+If we only want to run tests in one or more test modules, we can use the
+``--module`` command line argument. For example, if we just wanted to run
 ``tests/home.py``:
 
 .. code-block:: none
@@ -434,6 +434,21 @@ command line argument. For example, if we just wanted to run
 Since we only have one test module in this example, this doesn’t do anything
 different than normal, but this can be useful in test projects with multiple
 test modules.
+
+Skipping test modules
+^^^^^^^^^^^^^^^^^^^^^
+
+If we wanted to skip all tests in one or more test modules, we can use the
+``--skip-module`` command line argument, which uses the same syntax as
+``--module``. For example, if we wanted to skip all tests in ``tests/home.py``:
+
+.. code-block:: none
+
+    example_package --skip-module home
+
+Since we only have one test module in this example, this won't run any tests,
+and so isn't particularly helpful here, but this can be useful in test projects
+with multiple test modules.
 
 Running specific test cases or functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/test_projects.rst
+++ b/docs/source/test_projects.rst
@@ -216,6 +216,13 @@ argument:
 
     <test_package> --module <test_module> [<test_module> ...]
 
+To skip all test cases in one or more modules, use the ``--skip-module`` (or
+``-S``) argument:
+
+::
+
+    <test_package> --skip-module <test_module> [<test_module> ...]
+
 To run specific test case classes or methods, use the ``--test`` (or ``-t``)
 argument:
 
@@ -236,9 +243,10 @@ and method names.
 These arguments can be used together. When combined, they are processed in the
 following order:
 
-    1. ``--module`` reduces the set of tests to those in the specified modules
-    2. ``--test`` reduces the set of tests to the specified classes and methods
-    3. ``--skip`` removes the specified classes and methods from the set of tests
+    #. ``--skip-module`` removes the specified modules from the set of tests
+    #. ``--module`` reduces the set of tests to those in the specified modules
+    #. ``--test`` reduces the set of tests to the specified classes and methods
+    #. ``--skip`` removes the specified classes and methods from the set of tests
 
 
 Using Specific Browsers
@@ -320,6 +328,9 @@ attribute of the ``TestSuiteConfig`` class.
 List Available Tests
 --------------------
 
+Basic Usage
+~~~~~~~~~~~
+
 To print a list of available test classes and methods:
 
 ::
@@ -332,11 +343,21 @@ To include docstrings for each test class and method in output:
 
     <test_package> list --verbose
 
+
+Listing Specific Tests
+~~~~~~~~~~~~~~~~~~~~~~
+
 To only list test classes from specific modules:
 
 ::
 
     <test_package> list --module <test_module> [<test_module> ...]
+
+To omit specific modules:
+
+::
+
+    <test_package> list --skip-module <test_module> [<test_module> ...]
 
 To only list specific test classes:
 
@@ -349,6 +370,8 @@ To skip certain test classes in output:
 ::
 
     <test_package> --skip <TestClass> [<TestClass> ...]
+
+See `Running Specific Tests`_ for more info on these arguments.
 
 
 Project Structure

--- a/webdriver_test_tools/project/cmd/common.py
+++ b/webdriver_test_tools/project/cmd/common.py
@@ -2,7 +2,6 @@ import sys
 import textwrap
 
 from webdriver_test_tools.common import cmd
-from webdriver_test_tools.project import test_loader
 
 
 # Parent Parsers
@@ -10,14 +9,14 @@ from webdriver_test_tools.project import test_loader
 def get_test_parent_parser(parents=[]):
     """Returns an :class:`ArgumentParser
     <webdriver_test_tools.cmd.argparse.ArgumentParser>` with ``--test``,
-    ``--skip``, and ``--module`` arguments
+    ``--skip``, ``--module``, and ``--skip-module`` arguments
 
     :param parents: (Optional) List of ``ArgumentParser`` objects to use as
         parents for the test argument parser
 
     :return: :class:`ArgumentParser
         <webdriver_test_tools.cmd.argparse.ArgumentParser>` with ``--test``,
-        ``--skip``, and ``--module`` arguments
+        ``--skip``, ``--module``, and ``--skip-module`` arguments
     """
     # Adds --module, --test, and --skip arguments
     test_parent_parser = cmd.argparse.ArgumentParser(add_help=False,
@@ -27,6 +26,9 @@ def get_test_parent_parser(parents=[]):
     module_help = 'Run only tests in specific test modules'
     group.add_argument('-m', '--module', nargs='+', metavar='<module>',
                        help=module_help)
+    skip_module_help = 'Skip all tests in specific test modules'
+    group.add_argument('-S', '--skip-module', nargs='+', metavar='<module>',
+                       help=skip_module_help)
     test_help = textwrap.dedent('''\
                 Run specific test case classes or test methods.
                 Arguments should be in the format <TestCase>[.<method>]
@@ -74,14 +76,16 @@ def parse_test_args(args):
 
     :param args: The namespace returned by parser.parse_args()
 
-    :return: A dictionary mapping 'test_class_map', 'skip_class_map', and
-        'test_module_names' to the arguments passed via the command line
+    :return: A dictionary mapping 'test_class_map', 'skip_class_map',
+        'test_module_names', and 'skip_module_names' to the arguments passed
+        via the command line
     """
-    # get --test, --skip, and --module args
+    # get --test, --skip, --module, and --skip-module args
     return {
         'test_class_map': parse_test_names(args.test),
         'skip_class_map': parse_test_names(args.skip),
         'test_module_names': args.module,
+        'skip_module_names': args.skip_module,
     }
 
 

--- a/webdriver_test_tools/project/cmd/list.py
+++ b/webdriver_test_tools/project/cmd/list.py
@@ -68,13 +68,15 @@ def parse_list_args(tests_module, args):
 
 
 def list_tests(tests_module,
-               test_module_names=None, test_class_map=None, skip_class_map=None,
-               verbose=False):
+               test_module_names=None, skip_module_names=None,
+               test_class_map=None, skip_class_map=None, verbose=False):
     """Print a list of available tests
 
     :param tests_module: The module object for ``<test_project>.tests``
     :param test_module_names: (Optional) Parsed arg for ``--module`` command
         line argument
+    :param skip_module_names: (Optional) Parsed arg for ``--skip-module``
+        command line argument
     :param test_class_map: (Optional) Result of passing parsed arg for
         ``--test`` command line argument to :func:`parse_test_names()`
     :param skip_class_map: (Optional) Result of passing parsed arg for
@@ -82,7 +84,7 @@ def list_tests(tests_module,
     :param verbose: (Default = False) If True, print class and test method
         docstrings
     """
-    tests = load_project_tests(tests_module, test_module_names, test_class_map, skip_class_map)
+    tests = load_project_tests(tests_module, test_module_names, skip_module_names, test_class_map, skip_class_map)
     module_map = _module_map(tests, tests_module)
     for module, test_list in module_map.items():
         _print_module(module, test_list, verbose=verbose)

--- a/webdriver_test_tools/project/cmd/run.py
+++ b/webdriver_test_tools/project/cmd/run.py
@@ -221,8 +221,8 @@ def parse_run_args(tests_module, config_module, args):
 
 def run_tests(tests_module, config_module,
               browser_classes=None, test_class_map=None, skip_class_map=None,
-              test_module_names=None, browserstack=False, headless=False,
-              verbosity=None):
+              test_module_names=None, skip_module_names=None,
+              browserstack=False, headless=False, verbosity=None):
     """Run tests using parsed args and project modules
 
     :param tests_module: The module object for ``<test_project>.tests``
@@ -236,6 +236,8 @@ def run_tests(tests_module, config_module,
         ``--skip`` command line argument to :func:`parse_test_names()`
     :param test_module_names: (Optional) Parsed arg for ``--module`` command
         line argument
+    :param skip_module_names: (Optional) Parsed arg for ``--skip-module``
+        command line argument
     :param browserstack: (Default = False) If True, generated test cases should
         run on BrowserStack
     :param headless: (Default = False) If True, configure driver to run tests
@@ -248,7 +250,7 @@ def run_tests(tests_module, config_module,
     # Enable graceful Ctrl+C handling
     unittest.installHandler()
     # Load WebDriverTestCase subclasses from project tests
-    tests = load_project_tests(tests_module, test_module_names, test_class_map, skip_class_map)
+    tests = load_project_tests(tests_module, test_module_names, skip_module_names, test_class_map, skip_class_map)
     # Generate browser test cases from the loaded WebDriverTestCase classes
     browser_test_suite = test_factory.generate_browser_test_suite(
         tests, browser_classes, test_class_map, skip_class_map,

--- a/webdriver_test_tools/project/templates/project_root/README.rst.j2
+++ b/webdriver_test_tools/project/templates/project_root/README.rst.j2
@@ -216,6 +216,13 @@ argument:
 
     {{test_package}} --module <test_module> [<test_module> ...]
 
+To skip all test cases in one or more modules, use the ``--skip-module`` (or
+``-S``) argument:
+
+::
+
+    {{test_package}} --skip-module <test_module> [<test_module> ...]
+
 To run specific test case classes or methods, use the ``--test`` (or ``-t``)
 argument:
 
@@ -236,9 +243,10 @@ and method names.
 These arguments can be used together. When combined, they are processed in the
 following order:
 
-    1. ``--module`` reduces the set of tests to those in the specified modules
-    2. ``--test`` reduces the set of tests to the specified classes and methods
-    3. ``--skip`` removes the specified classes and methods from the set of tests
+    #. ``--skip-module`` removes the specified modules from the set of tests
+    #. ``--module`` reduces the set of tests to those in the specified modules
+    #. ``--test`` reduces the set of tests to the specified classes and methods
+    #. ``--skip`` removes the specified classes and methods from the set of tests
 
 
 Using Specific Browsers
@@ -320,6 +328,9 @@ attribute of the ``TestSuiteConfig`` class.
 List Available Tests
 --------------------
 
+Basic Usage
+~~~~~~~~~~~
+
 To print a list of available test classes and methods:
 
 ::
@@ -332,11 +343,21 @@ To include docstrings for each test class and method in output:
 
     {{test_package}} list --verbose
 
+
+Listing Specific Tests
+~~~~~~~~~~~~~~~~~~~~~~
+
 To only list test classes from specific modules:
 
 ::
 
     {{test_package}} list --module <test_module> [<test_module> ...]
+
+To omit specific modules:
+
+::
+
+    {{test_package}} list --skip-module <test_module> [<test_module> ...]
 
 To only list specific test classes:
 
@@ -349,6 +370,8 @@ To skip certain test classes in output:
 ::
 
     {{test_package}} --skip <TestClass> [<TestClass> ...]
+
+See `Running Specific Tests`_ for more info on these arguments.
 
 
 Project Structure


### PR DESCRIPTION
## Pull Request Description

### Overview

Added `--skip-module`/`-S` argument to `run` and `list` commands, allowing entire test modules to be skipped

### Details

`project.cmd.common`:

- Added `--skip-module`/`-S` argument to test parent parser
- Dictionary returned when parsing test args now includes `'skip_module_names'` with modules to skip

`project.test_loader`:

- `load_project_tests()` and `get_test_modules()` now take optional `skip_module_names` argument. Modules matching these names are filtered out before checking `test_module_names`

`project.cmd.list`:

- `list_tests()` now accepts `skip_module_names` and passes to `load_project_tests()`

`project.cmd.run`:

- `run_tests()` now accepts `skip_module_names` and passes to `load_project_tests()`


## Types of Changes

* [x] New feature (non-breaking change which adds functionality)
* [x] This change requires a documentation update

